### PR TITLE
First pass Metric Exporter implementation.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ googleJavaFormat {
 
 dependencies {
     api("com.newrelic.telemetry:telemetry:0.4.0")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.2.4")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.3.0")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.3.1")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
@@ -6,8 +6,7 @@ import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Map;
 
-// todo: this is a terrible name.
-public class CommonUtils {
+public class AttributesSupport {
 
   static Attributes populateLibraryInfo(
       Attributes attributes, InstrumentationLibraryInfo instrumentationLibraryInfo) {

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/CommonUtils.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/CommonUtils.java
@@ -1,0 +1,55 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import com.newrelic.telemetry.Attributes;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.resources.Resource;
+import io.opentelemetry.trace.AttributeValue;
+import java.util.Map;
+
+// todo: this is a terrible name.
+public class CommonUtils {
+
+  static Attributes populateLibraryInfo(
+      Attributes attributes, InstrumentationLibraryInfo instrumentationLibraryInfo) {
+    if (instrumentationLibraryInfo != null) {
+      if (instrumentationLibraryInfo.getName() != null
+          && !instrumentationLibraryInfo.getName().isEmpty()) {
+        attributes.put("instrumentation.name", instrumentationLibraryInfo.getName());
+      }
+      if (instrumentationLibraryInfo.getVersion() != null
+          && !instrumentationLibraryInfo.getVersion().isEmpty()) {
+        attributes.put("instrumentation.version", instrumentationLibraryInfo.getVersion());
+      }
+    }
+    return attributes;
+  }
+
+  static Attributes addResourceAttributes(Attributes attributes, Resource resource) {
+    if (resource != null) {
+      Map<String, AttributeValue> labelsMap = resource.getLabels();
+      putInAttributes(attributes, labelsMap);
+    }
+    return attributes;
+  }
+
+  static void putInAttributes(
+      Attributes attributes, Map<String, AttributeValue> originalAttributes) {
+    originalAttributes.forEach(
+        (key, value) -> {
+          switch (value.getType()) {
+            case STRING:
+              attributes.put(key, value.getStringValue());
+              break;
+            case LONG:
+              attributes.put(key, value.getLongValue());
+              break;
+            case BOOLEAN:
+              attributes.put(key, value.getBooleanValue());
+              break;
+            case DOUBLE:
+              attributes.put(key, value.getDoubleValue());
+              break;
+          }
+        });
+  }
+}

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/CommonUtils.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/CommonUtils.java
@@ -1,9 +1,9 @@
 package com.newrelic.telemetry.opentelemetry.export;
 
 import com.newrelic.telemetry.Attributes;
+import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.trace.AttributeValue;
 import java.util.Map;
 
 // todo: this is a terrible name.
@@ -26,7 +26,7 @@ public class CommonUtils {
 
   static Attributes addResourceAttributes(Attributes attributes, Resource resource) {
     if (resource != null) {
-      Map<String, AttributeValue> labelsMap = resource.getLabels();
+      Map<String, AttributeValue> labelsMap = resource.getAttributes();
       putInAttributes(attributes, labelsMap);
     }
     return attributes;

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/DeltaDoubleCounter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/DeltaDoubleCounter.java
@@ -1,0 +1,18 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+
+public class DeltaDoubleCounter {
+
+  private DoublePoint previousValue = null;
+
+  double delta(DoublePoint newValue) {
+    if (previousValue == null) {
+      previousValue = newValue;
+      return previousValue.getValue();
+    }
+    double result = newValue.getValue() - previousValue.getValue();
+    previousValue = newValue;
+    return result;
+  }
+}

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/DeltaLongCounter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/DeltaLongCounter.java
@@ -1,0 +1,18 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+
+public class DeltaLongCounter {
+
+  private LongPoint previousValue = null;
+
+  long delta(LongPoint newValue) {
+    if (previousValue == null) {
+      previousValue = newValue;
+      return previousValue.getValue();
+    }
+    long result = newValue.getValue() - previousValue.getValue();
+    previousValue = newValue;
+    return result;
+  }
+}

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -1,0 +1,173 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.metrics.Count;
+import com.newrelic.telemetry.metrics.Gauge;
+import com.newrelic.telemetry.metrics.Metric;
+import com.newrelic.telemetry.metrics.Summary;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.Point;
+import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class MetricPointAdapter {
+
+  // Ideally, we would not have to do this work, and the OTel SDK would be configurable to
+  // make deltas for us automatically.
+  private final Map<Key, DeltaLongCounter> deltaLongCountersByDescriptor = new HashMap<>();
+  private final Map<Key, DeltaDoubleCounter> deltaDoubleCountersByDescriptor = new HashMap<>();
+  private final TimeTracker timeTracker;
+
+  public MetricPointAdapter(TimeTracker timeTracker) {
+    this.timeTracker = timeTracker;
+  }
+
+  Collection<Metric> buildMetricsFromPoint(
+      Descriptor descriptor, Type type, Attributes attributes, Point point) {
+    if (point instanceof LongPoint) {
+      return buildLongPointMetrics(descriptor, type, attributes, (LongPoint) point);
+    }
+    if (point instanceof DoublePoint) {
+      return buildDoublePointMetrics(descriptor, type, attributes, (DoublePoint) point);
+    }
+    if (point instanceof SummaryPoint) {
+      return buildSummaryPointMetrics(descriptor, attributes, (SummaryPoint) point);
+    }
+    return emptyList();
+  }
+
+  private Collection<Metric> buildMetricsFromSimpleType(
+      Descriptor descriptor,
+      Type type,
+      Attributes attributes,
+      double value,
+      long epochNanos,
+      long startEpochNanos) {
+    switch (type) {
+      case NON_MONOTONIC_LONG:
+      case NON_MONOTONIC_DOUBLE:
+        return singleton(
+            new Gauge(descriptor.getName(), value, NANOSECONDS.toMillis(epochNanos), attributes));
+
+      case MONOTONIC_LONG:
+      case MONOTONIC_DOUBLE:
+        return singleton(
+            new Count(
+                descriptor.getName(),
+                value,
+                NANOSECONDS.toMillis(startEpochNanos),
+                NANOSECONDS.toMillis(epochNanos),
+                attributes));
+
+      default:
+        // log something about unhandled types
+        break;
+    }
+    return emptyList();
+  }
+
+  boolean isNonMonotonic(Type type) {
+    return type != Type.NON_MONOTONIC_DOUBLE && type != Type.NON_MONOTONIC_LONG;
+  }
+
+  private Collection<Metric> buildDoublePointMetrics(
+      Descriptor descriptor, Type type, Attributes attributes, DoublePoint point) {
+
+    double value = point.getValue();
+    if (isNonMonotonic(type)) {
+      DeltaDoubleCounter deltaDoubleCounter =
+          deltaDoubleCountersByDescriptor.computeIfAbsent(
+              new Key(descriptor, type), d -> new DeltaDoubleCounter());
+      value = deltaDoubleCounter.delta(point);
+    }
+    return buildMetricsFromSimpleType(
+        descriptor, type, attributes, value, point.getEpochNanos(), timeTracker.getPreviousTime());
+  }
+
+  private Collection<Metric> buildLongPointMetrics(
+      Descriptor descriptor, Type type, Attributes attributes, LongPoint point) {
+    long value = point.getValue();
+    if (isNonMonotonic(type)) {
+      DeltaLongCounter deltaLongCounter =
+          deltaLongCountersByDescriptor.computeIfAbsent(
+              new Key(descriptor, type), d -> new DeltaLongCounter());
+      value = deltaLongCounter.delta(point);
+    }
+    return buildMetricsFromSimpleType(
+        descriptor, type, attributes, value, point.getEpochNanos(), timeTracker.getPreviousTime());
+  }
+
+  private Collection<Metric> buildSummaryPointMetrics(
+      Descriptor descriptor, Attributes attributes, SummaryPoint point) {
+    List<ValueAtPercentile> percentileValues = point.getPercentileValues();
+
+    double min = Double.NaN;
+    double max = Double.NaN;
+    for (ValueAtPercentile percentileValue : percentileValues) {
+      if (percentileValue.getPercentile() == 0.0) {
+        min = percentileValue.getValue();
+      }
+      if (percentileValue.getPercentile() == 100.0) {
+        max = percentileValue.getValue();
+      }
+    }
+    // todo: send up other percentiles as gauges.
+
+    return singleton(
+        new Summary(
+            descriptor.getName(),
+            (int) point.getCount(),
+            point.getSum(),
+            min,
+            max,
+            NANOSECONDS.toMillis(timeTracker.getPreviousTime()),
+            NANOSECONDS.toMillis(point.getEpochNanos()),
+            attributes));
+  }
+
+  private static class Key {
+
+    private final Descriptor descriptor;
+    private final Type type;
+
+    public Key(Descriptor descriptor, Type type) {
+      this.descriptor = descriptor;
+      this.type = type;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof Key)) {
+        return false;
+      }
+
+      Key key = (Key) o;
+
+      if (descriptor != null ? !descriptor.equals(key.descriptor) : key.descriptor != null) {
+        return false;
+      }
+      return type == key.type;
+    }
+
+    @Override
+    public int hashCode() {
+      int result = descriptor != null ? descriptor.hashCode() : 0;
+      result = 31 * result + (type != null ? type.hashCode() : 0);
+      return result;
+    }
+  }
+}

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -48,36 +48,6 @@ public class MetricPointAdapter {
     return emptyList();
   }
 
-  private Collection<Metric> buildMetricsFromSimpleType(
-      Descriptor descriptor,
-      Type type,
-      Attributes attributes,
-      double value,
-      long epochNanos,
-      long startEpochNanos) {
-    switch (type) {
-      case NON_MONOTONIC_LONG:
-      case NON_MONOTONIC_DOUBLE:
-        return singleton(
-            new Gauge(descriptor.getName(), value, NANOSECONDS.toMillis(epochNanos), attributes));
-
-      case MONOTONIC_LONG:
-      case MONOTONIC_DOUBLE:
-        return singleton(
-            new Count(
-                descriptor.getName(),
-                value,
-                NANOSECONDS.toMillis(startEpochNanos),
-                NANOSECONDS.toMillis(epochNanos),
-                attributes));
-
-      default:
-        // maybe log something about unhandled types?
-        break;
-    }
-    return emptyList();
-  }
-
   private boolean isNonMonotonic(Type type) {
     return type != Type.NON_MONOTONIC_DOUBLE && type != Type.NON_MONOTONIC_LONG;
   }
@@ -107,6 +77,36 @@ public class MetricPointAdapter {
     }
     return buildMetricsFromSimpleType(
         descriptor, type, attributes, value, point.getEpochNanos(), timeTracker.getPreviousTime());
+  }
+
+  private Collection<Metric> buildMetricsFromSimpleType(
+      Descriptor descriptor,
+      Type type,
+      Attributes attributes,
+      double value,
+      long epochNanos,
+      long startEpochNanos) {
+    switch (type) {
+      case NON_MONOTONIC_LONG:
+      case NON_MONOTONIC_DOUBLE:
+        return singleton(
+            new Gauge(descriptor.getName(), value, NANOSECONDS.toMillis(epochNanos), attributes));
+
+      case MONOTONIC_LONG:
+      case MONOTONIC_DOUBLE:
+        return singleton(
+            new Count(
+                descriptor.getName(),
+                value,
+                NANOSECONDS.toMillis(startEpochNanos),
+                NANOSECONDS.toMillis(epochNanos),
+                attributes));
+
+      default:
+        // maybe log something about unhandled types?
+        break;
+    }
+    return emptyList();
   }
 
   private Collection<Metric> buildSummaryPointMetrics(

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -115,6 +115,8 @@ public class MetricPointAdapter {
 
     double min = Double.NaN;
     double max = Double.NaN;
+    // note: The MinMaxSumCount aggregator, which generates Summaries puts the min at %ile 0.0
+    // and the max at %ile 100.0.
     for (ValueAtPercentile percentileValue : percentileValues) {
       if (percentileValue.getPercentile() == 0.0) {
         min = percentileValue.getValue();

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -88,7 +88,7 @@ public class MetricPointAdapter {
     if (isNonMonotonic(type)) {
       DeltaDoubleCounter deltaDoubleCounter =
           deltaDoubleCountersByDescriptor.computeIfAbsent(
-              new Key(descriptor, type), d -> new DeltaDoubleCounter());
+              new Key(descriptor, type, point.getLabels()), d -> new DeltaDoubleCounter());
       value = deltaDoubleCounter.delta(point);
     }
     return buildMetricsFromSimpleType(
@@ -101,7 +101,7 @@ public class MetricPointAdapter {
     if (isNonMonotonic(type)) {
       DeltaLongCounter deltaLongCounter =
           deltaLongCountersByDescriptor.computeIfAbsent(
-              new Key(descriptor, type), d -> new DeltaLongCounter());
+              new Key(descriptor, type, point.getLabels()), d -> new DeltaLongCounter());
       value = deltaLongCounter.delta(point);
     }
     return buildMetricsFromSimpleType(
@@ -137,13 +137,14 @@ public class MetricPointAdapter {
   }
 
   private static class Key {
-
     private final Descriptor descriptor;
     private final Type type;
+    private final Map<String, String> labels;
 
-    public Key(Descriptor descriptor, Type type) {
+    public Key(Descriptor descriptor, Type type, Map<String, String> labels) {
       this.descriptor = descriptor;
       this.type = type;
+      this.labels = labels;
     }
 
     @Override
@@ -160,13 +161,17 @@ public class MetricPointAdapter {
       if (descriptor != null ? !descriptor.equals(key.descriptor) : key.descriptor != null) {
         return false;
       }
-      return type == key.type;
+      if (type != key.type) {
+        return false;
+      }
+      return labels != null ? labels.equals(key.labels) : key.labels == null;
     }
 
     @Override
     public int hashCode() {
       int result = descriptor != null ? descriptor.hashCode() : 0;
       result = 31 * result + (type != null ? type.hashCode() : 0);
+      result = 31 * result + (labels != null ? labels.hashCode() : 0);
       return result;
     }
   }

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -35,6 +35,7 @@ public class MetricPointAdapter {
 
   Collection<Metric> buildMetricsFromPoint(
       Descriptor descriptor, Type type, Attributes attributes, Point point) {
+    point.getLabels().forEach(attributes::put);
     if (point instanceof LongPoint) {
       return buildLongPointMetrics(descriptor, type, attributes, (LongPoint) point);
     }
@@ -71,13 +72,13 @@ public class MetricPointAdapter {
                 attributes));
 
       default:
-        // log something about unhandled types
+        // maybe log something about unhandled types?
         break;
     }
     return emptyList();
   }
 
-  boolean isNonMonotonic(Type type) {
+  private boolean isNonMonotonic(Type type) {
     return type != Type.NON_MONOTONIC_DOUBLE && type != Type.NON_MONOTONIC_LONG;
   }
 

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -52,9 +52,7 @@ public class NewRelicMetricExporter implements MetricExporter {
       for (Point point : points) {
         Collection<Metric> metricsFromPoint =
             buildMetricsFromPoint(descriptor, type, attributes, point);
-        for (Metric metric2 : metricsFromPoint) {
-          buffer.addMetric(metric2);
-        }
+        metricsFromPoint.forEach(buffer::addMetric);
       }
     }
     telemetryClient.sendBatch(buffer.createBatch());

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -2,6 +2,7 @@ package com.newrelic.telemetry.opentelemetry.export;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.TelemetryClient;
@@ -96,8 +97,8 @@ public class NewRelicMetricExporter implements MetricExporter {
             point.getSum(),
             min,
             max,
-            point.getStartEpochNanos() / 1_000_000,
-            point.getEpochNanos() / 1_000_000,
+            NANOSECONDS.toMillis(point.getStartEpochNanos()),
+            NANOSECONDS.toMillis(point.getEpochNanos()),
             attributes));
   }
 
@@ -126,7 +127,7 @@ public class NewRelicMetricExporter implements MetricExporter {
       case NON_MONOTONIC_LONG:
       case NON_MONOTONIC_DOUBLE:
         return singleton(
-            new Gauge(descriptor.getName(), value, epochNanos / 1_000_000, attributes));
+            new Gauge(descriptor.getName(), value, NANOSECONDS.toMillis(epochNanos), attributes));
 
       case MONOTONIC_LONG:
       case MONOTONIC_DOUBLE:
@@ -136,8 +137,8 @@ public class NewRelicMetricExporter implements MetricExporter {
             new Count(
                 descriptor.getName(),
                 value,
-                startEpochNanos / 1_000_000,
-                epochNanos / 1_000_000,
+                NANOSECONDS.toMillis(startEpochNanos),
+                NANOSECONDS.toMillis(epochNanos),
                 attributes));
 
       default:

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -68,13 +68,13 @@ public class NewRelicMetricExporter implements MetricExporter {
       return buildDoublePointMetrics(descriptor, type, attributes, (DoublePoint) point);
     }
     if (point instanceof SummaryPoint) {
-      return buildSummaryPointMetrics(descriptor, type, attributes, (SummaryPoint) point);
+      return buildSummaryPointMetrics(descriptor, attributes, (SummaryPoint) point);
     }
     return emptyList();
   }
 
   private Collection<Metric> buildSummaryPointMetrics(
-      Descriptor descriptor, Type type, Attributes attributes, SummaryPoint point) {
+      Descriptor descriptor, Attributes attributes, SummaryPoint point) {
     List<ValueAtPercentile> percentileValues = point.getPercentileValues();
 
     double min = Double.NaN;

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -1,46 +1,28 @@
 package com.newrelic.telemetry.opentelemetry.export;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
-
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.SimpleMetricBatchSender;
 import com.newrelic.telemetry.TelemetryClient;
-import com.newrelic.telemetry.metrics.Count;
-import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.MetricBatchSenderBuilder;
 import com.newrelic.telemetry.metrics.MetricBuffer;
-import com.newrelic.telemetry.metrics.Summary;
 import io.opentelemetry.sdk.common.Clock;
 import io.opentelemetry.sdk.internal.MillisClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
-import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
-import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
-import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 
 public class NewRelicMetricExporter implements MetricExporter {
 
   private final Attributes commonAttributes;
   private final TelemetryClient telemetryClient;
-
-  // Ideally, we would not have to do this work, and the OTel SDK would be configurable to
-  // make deltas for us automatically.
-  private final Map<Key, DeltaLongCounter> deltaLongCountersByDescriptor = new HashMap<>();
-  private final Map<Key, DeltaDoubleCounter> deltaDoubleCountersByDescriptor = new HashMap<>();
   private final TimeTracker timeTracker;
+  private final MetricPointAdapter metricPointAdapter;
 
   public NewRelicMetricExporter(
       TelemetryClient telemetryClient, Clock clock, Attributes serviceAttributes) {
@@ -53,6 +35,7 @@ public class NewRelicMetricExporter implements MetricExporter {
             .copy()
             .put("instrumentation.provider", "opentelemetry")
             .put("collector.name", "newrelic-opentelemetry-exporter");
+    this.metricPointAdapter = new MetricPointAdapter(timeTracker);
   }
 
   public static Builder newBuilder() {
@@ -61,7 +44,6 @@ public class NewRelicMetricExporter implements MetricExporter {
 
   @Override
   public ResultCode export(Collection<MetricData> metrics) {
-    timeTracker.tick();
     MetricBuffer buffer = MetricBuffer.builder().attributes(commonAttributes).build();
     for (MetricData metric : metrics) {
       Descriptor descriptor = metric.getDescriptor();
@@ -77,150 +59,13 @@ public class NewRelicMetricExporter implements MetricExporter {
       Collection<Point> points = metric.getPoints();
       for (Point point : points) {
         Collection<Metric> metricsFromPoint =
-            buildMetricsFromPoint(descriptor, type, attributes, point);
+            metricPointAdapter.buildMetricsFromPoint(descriptor, type, attributes, point);
         metricsFromPoint.forEach(buffer::addMetric);
       }
     }
+    timeTracker.tick();
     telemetryClient.sendBatch(buffer.createBatch());
     return ResultCode.SUCCESS;
-  }
-
-  private Collection<Metric> buildMetricsFromPoint(
-      Descriptor descriptor, Type type, Attributes attributes, Point point) {
-    if (point instanceof LongPoint) {
-      return buildLongPointMetrics(descriptor, type, attributes, (LongPoint) point);
-    }
-    if (point instanceof DoublePoint) {
-      return buildDoublePointMetrics(descriptor, type, attributes, (DoublePoint) point);
-    }
-    if (point instanceof SummaryPoint) {
-      return buildSummaryPointMetrics(descriptor, attributes, (SummaryPoint) point);
-    }
-    return emptyList();
-  }
-
-  private Collection<Metric> buildSummaryPointMetrics(
-      Descriptor descriptor, Attributes attributes, SummaryPoint point) {
-    List<ValueAtPercentile> percentileValues = point.getPercentileValues();
-
-    double min = Double.NaN;
-    double max = Double.NaN;
-    for (ValueAtPercentile percentileValue : percentileValues) {
-      if (percentileValue.getPercentile() == 0.0) {
-        min = percentileValue.getValue();
-      }
-      if (percentileValue.getPercentile() == 100.0) {
-        max = percentileValue.getValue();
-      }
-    }
-    // todo: send up other percentiles as gauges.
-
-    return singleton(
-        new Summary(
-            descriptor.getName(),
-            (int) point.getCount(),
-            point.getSum(),
-            min,
-            max,
-            NANOSECONDS.toMillis(timeTracker.getPreviousTime()),
-            NANOSECONDS.toMillis(point.getEpochNanos()),
-            attributes));
-  }
-
-  private Collection<Metric> buildLongPointMetrics(
-      Descriptor descriptor, Type type, Attributes attributes, LongPoint point) {
-    long value = point.getValue();
-    if (isNonMonotonic(type)) {
-      DeltaLongCounter deltaLongCounter =
-          deltaLongCountersByDescriptor.computeIfAbsent(
-              new Key(descriptor, type), d -> new DeltaLongCounter());
-      value = deltaLongCounter.delta(point);
-    }
-    return buildMetricsFromSimpleType(
-        descriptor, type, attributes, value, point.getEpochNanos(), timeTracker.getPreviousTime());
-  }
-
-  private Collection<Metric> buildDoublePointMetrics(
-      Descriptor descriptor, Type type, Attributes attributes, DoublePoint point) {
-
-    double value = point.getValue();
-    if (isNonMonotonic(type)) {
-      DeltaDoubleCounter deltaDoubleCounter =
-          deltaDoubleCountersByDescriptor.computeIfAbsent(
-              new Key(descriptor, type), d -> new DeltaDoubleCounter());
-      value = deltaDoubleCounter.delta(point);
-    }
-    return buildMetricsFromSimpleType(
-        descriptor, type, attributes, value, point.getEpochNanos(), timeTracker.getPreviousTime());
-  }
-
-  private boolean isNonMonotonic(Type type) {
-    return type != Type.NON_MONOTONIC_DOUBLE && type != Type.NON_MONOTONIC_LONG;
-  }
-
-  private Collection<Metric> buildMetricsFromSimpleType(
-      Descriptor descriptor,
-      Type type,
-      Attributes attributes,
-      double value,
-      long epochNanos,
-      long startEpochNanos) {
-    switch (type) {
-      case NON_MONOTONIC_LONG:
-      case NON_MONOTONIC_DOUBLE:
-        return singleton(
-            new Gauge(descriptor.getName(), value, NANOSECONDS.toMillis(epochNanos), attributes));
-
-      case MONOTONIC_LONG:
-      case MONOTONIC_DOUBLE:
-        return singleton(
-            new Count(
-                descriptor.getName(),
-                value,
-                NANOSECONDS.toMillis(startEpochNanos),
-                NANOSECONDS.toMillis(epochNanos),
-                attributes));
-
-      default:
-        // log something about unhandled types
-        break;
-    }
-    return emptyList();
-  }
-
-  public static class Key {
-
-    private final Descriptor descriptor;
-    private final Type type;
-
-    public Key(Descriptor descriptor, Type type) {
-      this.descriptor = descriptor;
-      this.type = type;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof Key)) {
-        return false;
-      }
-
-      Key key = (Key) o;
-
-      if (descriptor != null ? !descriptor.equals(key.descriptor) : key.descriptor != null) {
-        return false;
-      }
-      return type == key.type;
-    }
-
-    @Override
-    public int hashCode() {
-      int result = descriptor != null ? descriptor.hashCode() : 0;
-      result = 31 * result + (type != null ? type.hashCode() : 0);
-      return result;
-    }
   }
 
   /**

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -1,0 +1,151 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.TelemetryClient;
+import com.newrelic.telemetry.metrics.Count;
+import com.newrelic.telemetry.metrics.Gauge;
+import com.newrelic.telemetry.metrics.Metric;
+import com.newrelic.telemetry.metrics.MetricBuffer;
+import com.newrelic.telemetry.metrics.Summary;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.Point;
+import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collection;
+import java.util.List;
+
+public class NewRelicMetricExporter implements MetricExporter {
+
+  private static final Attributes commonAttributes =
+      new Attributes()
+          .put("instrumentation.provider", "opentelemetry-java")
+          .put("collector.name", "newrelic-opentelemetry-exporter");
+  private final TelemetryClient telemetryClient;
+
+  public NewRelicMetricExporter(TelemetryClient telemetryClient) {
+    this.telemetryClient = telemetryClient;
+  }
+
+  @Override
+  public ResultCode export(Collection<MetricData> metrics) {
+    MetricBuffer buffer = MetricBuffer.builder().attributes(commonAttributes).build();
+    for (MetricData metric : metrics) {
+      Descriptor descriptor = metric.getDescriptor();
+      Type type = descriptor.getType();
+
+      Attributes attributes = new Attributes();
+      CommonUtils.addResourceAttributes(attributes, metric.getResource());
+      CommonUtils.populateLibraryInfo(attributes, metric.getInstrumentationLibraryInfo());
+      attributes.put("description", descriptor.getDescription());
+      attributes.put("unit", descriptor.getUnit());
+      descriptor.getConstantLabels().forEach(attributes::put);
+
+      Collection<Point> points = metric.getPoints();
+      for (Point point : points) {
+        Collection<Metric> metricsFromPoint =
+            buildMetricsFromPoint(descriptor, type, attributes, point);
+        for (Metric metric2 : metricsFromPoint) {
+          buffer.addMetric(metric2);
+        }
+      }
+    }
+    telemetryClient.sendBatch(buffer.createBatch());
+    return ResultCode.SUCCESS;
+  }
+
+  private Collection<Metric> buildMetricsFromPoint(
+      Descriptor descriptor, Type type, Attributes attributes, Point point) {
+    if (point instanceof LongPoint) {
+      return buildLongPointMetrics(descriptor, type, attributes, (LongPoint) point);
+    }
+    if (point instanceof DoublePoint) {
+      return buildDoublePointMetrics(descriptor, type, attributes, (DoublePoint) point);
+    }
+    if (point instanceof SummaryPoint) {
+      return buildSummaryPointMetrics(descriptor, type, attributes, (SummaryPoint) point);
+    }
+    return emptyList();
+  }
+
+  private Collection<Metric> buildSummaryPointMetrics(
+      Descriptor descriptor, Type type, Attributes attributes, SummaryPoint point) {
+    List<ValueAtPercentile> percentileValues = point.getPercentileValues();
+
+    double min = Double.NaN;
+    double max = Double.NaN;
+    for (ValueAtPercentile percentileValue : percentileValues) {
+      if (percentileValue.getPercentile() == 0.0) {
+        min = percentileValue.getValue();
+      }
+      if (percentileValue.getPercentile() == 100.0) {
+        max = percentileValue.getValue();
+      }
+    }
+    // todo: send up other percentiles as gauges.
+
+    return singleton(
+        new Summary(
+            descriptor.getName(),
+            (int) point.getCount(),
+            point.getSum(),
+            min,
+            max,
+            point.getStartEpochNanos() * 1_000_000,
+            point.getEpochNanos() * 1_000_000,
+            attributes));
+  }
+
+  private Collection<Metric> buildLongPointMetrics(
+      Descriptor descriptor, Type type, Attributes attributes, LongPoint point) {
+    long value = point.getValue();
+    return buildMetricsFromSimpleType(
+        descriptor, type, attributes, value, point.getEpochNanos(), point.getStartEpochNanos());
+  }
+
+  private Collection<Metric> buildDoublePointMetrics(
+      Descriptor descriptor, Type type, Attributes attributes, DoublePoint point) {
+    double value = point.getValue();
+    return buildMetricsFromSimpleType(
+        descriptor, type, attributes, value, point.getEpochNanos(), point.getStartEpochNanos());
+  }
+
+  private Collection<Metric> buildMetricsFromSimpleType(
+      Descriptor descriptor,
+      Type type,
+      Attributes attributes,
+      double value,
+      long epochNanos,
+      long startEpochNanos) {
+    switch (type) {
+      case NON_MONOTONIC_LONG:
+      case NON_MONOTONIC_DOUBLE:
+        return singleton(
+            new Gauge(descriptor.getName(), value, epochNanos / 1_000_000, attributes));
+
+      case MONOTONIC_LONG:
+      case MONOTONIC_DOUBLE:
+        // todo: I'm not sure if this is a count metric, and I'm not sure if we need to track deltas
+        // or not.
+        return singleton(
+            new Count(
+                descriptor.getName(),
+                value,
+                startEpochNanos / 1_000_000,
+                epochNanos / 1_000_000,
+                attributes));
+
+      default:
+        // log something about unhandled types
+        break;
+    }
+    return emptyList();
+  }
+}

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -98,8 +98,8 @@ public class NewRelicMetricExporter implements MetricExporter {
             point.getSum(),
             min,
             max,
-            point.getStartEpochNanos() * 1_000_000,
-            point.getEpochNanos() * 1_000_000,
+            point.getStartEpochNanos() / 1_000_000,
+            point.getEpochNanos() / 1_000_000,
             attributes));
   }
 

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -65,6 +65,11 @@ public class NewRelicMetricExporter implements MetricExporter {
     return ResultCode.SUCCESS;
   }
 
+  @Override
+  public void shutdown() {
+    telemetryClient.shutdown();
+  }
+
   private Attributes buildCommonAttributes(MetricData metric) {
     Attributes attributes = new Attributes();
     CommonUtils.addResourceAttributes(attributes, metric.getResource());

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -72,8 +72,8 @@ public class NewRelicMetricExporter implements MetricExporter {
 
   private Attributes buildCommonAttributes(MetricData metric) {
     Attributes attributes = new Attributes();
-    CommonUtils.addResourceAttributes(attributes, metric.getResource());
-    CommonUtils.populateLibraryInfo(attributes, metric.getInstrumentationLibraryInfo());
+    AttributesSupport.addResourceAttributes(attributes, metric.getResource());
+    AttributesSupport.populateLibraryInfo(attributes, metric.getInstrumentationLibraryInfo());
 
     Descriptor descriptor = metric.getDescriptor();
     attributes.put("description", descriptor.getDescription());

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -85,7 +85,7 @@ public class NewRelicSpanExporter implements SpanExporter {
     private URI uriOverride;
 
     /**
-     * A SpanBatchSender from the New Relic Telemetry SDK. This allows you to provide your own
+     * A TelemetryClient from the New Relic Telemetry SDK. This allows you to provide your own
      * custom-built SpanBatchSender (for instance, if you need to enable proxies, etc).
      *
      * @param telemetryClient the sender to use.

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 
 /**
  * The NewRelicSpanExporter takes a list of Span objects, converts them into a New Relic SpanBatch
- * instance and then sends it to the New Relic trace ingest API via a SpanBatchSender.
+ * instance and then sends it to the New Relic trace ingest API via a TelemetryClient.
  *
  * @since 0.1.0
  */
@@ -32,7 +32,7 @@ public class NewRelicSpanExporter implements SpanExporter {
    *
    * @param adapter An instance of SpanBatchAdapter that can turn list of open telemetry spans into
    *     New Relic SpanBatch.
-   * @param spanBatchSender An instance that sends a SpanBatch to the New Relic trace ingest API
+   * @param telemetryClient An instance that sends a SpanBatch to the New Relic trace ingest API
    * @since 0.1.0
    */
   NewRelicSpanExporter(SpanBatchAdapter adapter, TelemetryClient telemetryClient) {
@@ -86,9 +86,9 @@ public class NewRelicSpanExporter implements SpanExporter {
 
     /**
      * A TelemetryClient from the New Relic Telemetry SDK. This allows you to provide your own
-     * custom-built SpanBatchSender (for instance, if you need to enable proxies, etc).
+     * custom-built TelemetryClient (for instance, if you need to enable proxies, etc).
      *
-     * @param telemetryClient the sender to use.
+     * @param telemetryClient the client to use.
      * @return this builder's instance
      */
     public Builder telemetryClient(TelemetryClient telemetryClient) {

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -14,7 +14,7 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
-import java.util.List;
+import java.util.Collection;
 
 /**
  * The NewRelicSpanExporter takes a list of Span objects, converts them into a New Relic SpanBatch
@@ -50,7 +50,7 @@ public class NewRelicSpanExporter implements SpanExporter {
    * @return A ResultCode that indicates the execution status of the export operation
    */
   @Override
-  public ResultCode export(List<SpanData> openTelemetrySpans) {
+  public ResultCode export(Collection<SpanData> openTelemetrySpans) {
     SpanBatch spanBatch = adapter.adaptToSpanBatch(openTelemetrySpans);
     telemetryClient.sendBatch(spanBatch);
     return ResultCode.SUCCESS;

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -117,6 +117,7 @@ class SpanBatchAdapter {
     long endTime = span.getEndEpochNanos();
 
     long nanoDifference = endTime - startTime;
+    // note: we don't use NANOSECONDS.toMillis here, because we want to see  sub-ms resolution.
     return nanoDifference / 1_000_000d;
   }
 

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -12,7 +12,6 @@ import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.Span.SpanBuilder;
 import com.newrelic.telemetry.spans.SpanBatch;
 import io.opentelemetry.common.AttributeValue;
-import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.SpanId;
@@ -73,18 +72,6 @@ class SpanBatchAdapter {
 
   private static Attributes addPossibleInstrumentationAttributes(
       SpanData span, Attributes attributes) {
-    InstrumentationLibraryInfo instrumentationLibraryInfo = span.getInstrumentationLibraryInfo();
-    if (instrumentationLibraryInfo != null) {
-      if (instrumentationLibraryInfo.getName() != null
-          && !instrumentationLibraryInfo.getName().isEmpty()) {
-        attributes.put("instrumentation.name", instrumentationLibraryInfo.getName());
-      }
-      if (instrumentationLibraryInfo.getVersion() != null
-          && !instrumentationLibraryInfo.getVersion().isEmpty()) {
-        attributes.put("instrumentation.version", instrumentationLibraryInfo.getVersion());
-      }
-    }
-    return attributes;
     attributes = CommonUtils.populateLibraryInfo(attributes, span.getInstrumentationLibraryInfo());
     return CommonUtils.addResourceAttributes(attributes, span.getResource());
   }

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -17,7 +17,6 @@ import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -33,7 +32,7 @@ class SpanBatchAdapter {
             .put("collector.name", "newrelic-opentelemetry-exporter");
   }
 
-  SpanBatch adaptToSpanBatch(List<SpanData> openTracingSpans) {
+  SpanBatch adaptToSpanBatch(Collection<SpanData> openTracingSpans) {
     Collection<Span> newRelicSpans =
         openTracingSpans
             .stream()

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -71,13 +71,14 @@ class SpanBatchAdapter {
 
   private static Attributes addPossibleInstrumentationAttributes(
       SpanData span, Attributes attributes) {
-    attributes = CommonUtils.populateLibraryInfo(attributes, span.getInstrumentationLibraryInfo());
-    return CommonUtils.addResourceAttributes(attributes, span.getResource());
+    Attributes updatedAttributes =
+        AttributesSupport.populateLibraryInfo(attributes, span.getInstrumentationLibraryInfo());
+    return AttributesSupport.addResourceAttributes(updatedAttributes, span.getResource());
   }
 
   private static Attributes createIntrinsicAttributes(SpanData span, Attributes attributes) {
     Map<String, AttributeValue> originalAttributes = span.getAttributes();
-    CommonUtils.putInAttributes(attributes, originalAttributes);
+    AttributesSupport.putInAttributes(attributes, originalAttributes);
     return attributes;
   }
 
@@ -93,7 +94,7 @@ class SpanBatchAdapter {
     Resource resource = span.getResource();
     if (resource != null) {
       Map<String, AttributeValue> labelsMap = resource.getAttributes();
-      CommonUtils.putInAttributes(attributes, labelsMap);
+      AttributesSupport.putInAttributes(attributes, labelsMap);
     }
     return attributes;
   }

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -85,32 +85,13 @@ class SpanBatchAdapter {
       }
     }
     return attributes;
+    attributes = CommonUtils.populateLibraryInfo(attributes, span.getInstrumentationLibraryInfo());
+    return CommonUtils.addResourceAttributes(attributes, span.getResource());
   }
 
   private static Attributes createIntrinsicAttributes(SpanData span, Attributes attributes) {
     Map<String, AttributeValue> originalAttributes = span.getAttributes();
-    return addAttributes(attributes, originalAttributes);
-  }
-
-  private static Attributes addAttributes(
-      Attributes attributes, Map<String, AttributeValue> originalAttributes) {
-    originalAttributes.forEach(
-        (key, value) -> {
-          switch (value.getType()) {
-            case STRING:
-              attributes.put(key, value.getStringValue());
-              break;
-            case LONG:
-              attributes.put(key, value.getLongValue());
-              break;
-            case BOOLEAN:
-              attributes.put(key, value.getBooleanValue());
-              break;
-            case DOUBLE:
-              attributes.put(key, value.getDoubleValue());
-              break;
-          }
-        });
+    CommonUtils.putInAttributes(attributes, originalAttributes);
     return attributes;
   }
 
@@ -126,7 +107,7 @@ class SpanBatchAdapter {
     Resource resource = span.getResource();
     if (resource != null) {
       Map<String, AttributeValue> labelsMap = resource.getAttributes();
-      addAttributes(attributes, labelsMap);
+      CommonUtils.putInAttributes(attributes, labelsMap);
     }
     return attributes;
   }

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/TimeTracker.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/TimeTracker.java
@@ -1,0 +1,28 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import io.opentelemetry.sdk.common.Clock;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class TimeTracker {
+
+  private final Clock clock;
+  private final AtomicLong previousTime;
+
+  public TimeTracker(Clock clock) {
+    this.clock = clock;
+    this.previousTime = new AtomicLong(clock.now());
+  }
+
+  // call this at the end of the harvest/report
+  public void tick() {
+    previousTime.set(clock.now());
+  }
+
+  public long getCurrentTime() {
+    return clock.now();
+  }
+
+  public long getPreviousTime() {
+    return previousTime.get();
+  }
+}

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -89,7 +89,7 @@ public class BasicExample {
     BoundLongMeasure boundTimer = spanTimer.bind("spanName", "testSpan");
 
     Random random = new Random();
-    for (int i = 0; i < 1000; i++) {
+    for (int i = 0; i < 10; i++) {
       long startTime = System.currentTimeMillis();
       Span span = tracer.spanBuilder("testSpan").setSpanKind(Kind.INTERNAL).startSpan();
       try (Scope scope = tracer.withSpan(span)) {

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -22,6 +22,7 @@ public class BasicExample {
         NewRelicSpanExporter.newBuilder()
             .apiKey(System.getenv("INSIGHTS_INSERT_KEY"))
             .commonAttributes(new Attributes().put("service.name", "best service ever"))
+            .enableAuditLogging()
             .build();
 
     // 2. Build the OpenTelemetry `BatchSpansProcessor` with the `NewRelicSpanExporter`
@@ -43,8 +44,6 @@ public class BasicExample {
     // clean up so the JVM can exit. Note: the spanProcessor will flush any spans to the exporter
     // before it exits.
     spanProcessor.shutdown();
-    // note: it shouldn't be necessary to explicitly shut down the exporter.
-    // See https://github.com/open-telemetry/opentelemetry-java/issues/965
-    exporter.shutdown();
+    Thread.sleep(10000);
   }
 }

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -106,8 +106,8 @@ public class BasicExample {
 
     // clean up so the JVM can exit. Note: these will flush any data to the exporter
     // before they exit.
-    intervalMetricReader.shutdown();
     spanProcessor.shutdown();
+    intervalMetricReader.shutdown();
   }
 
   private static void doSomeSimulatedWork(

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -1,14 +1,28 @@
 package com.newrelic.telemetry.opentelemetry.examples;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.OkHttpPoster;
+import com.newrelic.telemetry.SimpleMetricBatchSender;
+import com.newrelic.telemetry.SimpleSpanBatchSender;
+import com.newrelic.telemetry.TelemetryClient;
+import com.newrelic.telemetry.metrics.MetricBatchSender;
+import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
+import com.newrelic.telemetry.spans.SpanBatchSender;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
+import io.opentelemetry.metrics.LongCounter;
+import io.opentelemetry.metrics.Meter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.internal.MillisClock;
+import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import io.opentelemetry.sdk.trace.export.BatchSpansProcessor;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.Tracer;
+import java.time.Duration;
+import java.util.Collections;
 
 public class BasicExample {
 
@@ -17,12 +31,23 @@ public class BasicExample {
     // example to show how you can manually create a tracer for experimentation.
     // See the OpenTelemetry documentation at https://opentelemetry.io for more normal usage.
 
+    String apiKey = System.getenv("INSIGHTS_INSERT_KEY");
+
+    OkHttpPoster httpPoster = new OkHttpPoster(Duration.ofSeconds(2));
+    MetricBatchSender metricBatchSender =
+        SimpleMetricBatchSender.builder(apiKey).httpPoster(httpPoster).enableAuditLogging().build();
+    SpanBatchSender spanBatchSender =
+        SimpleSpanBatchSender.builder(apiKey).httpPoster(httpPoster).enableAuditLogging().build();
+    TelemetryClient telemetryClient = new TelemetryClient(metricBatchSender, spanBatchSender);
+
+    MetricExporter metricExporter =
+        new NewRelicMetricExporter(telemetryClient, MillisClock.getInstance());
+
     // 1. Create a `NewRelicSpanExporter`
     NewRelicSpanExporter exporter =
         NewRelicSpanExporter.newBuilder()
-            .apiKey(System.getenv("INSIGHTS_INSERT_KEY"))
+            .telemetryClient(telemetryClient)
             .commonAttributes(new Attributes().put("service.name", "best service ever"))
-            .enableAuditLogging()
             .build();
 
     // 2. Build the OpenTelemetry `BatchSpansProcessor` with the `NewRelicSpanExporter`
@@ -31,19 +56,38 @@ public class BasicExample {
     // 3. Add the span processor to the TracerProvider from the SDK
     OpenTelemetrySdk.getTracerProvider().addSpanProcessor(spanProcessor);
 
+    IntervalMetricReader intervalMetricReader =
+        IntervalMetricReader.builder()
+            .setMetricProducers(
+                Collections.singleton(OpenTelemetrySdk.getMeterProvider().getMetricProducer()))
+            .setExportIntervalMillis(5000)
+            .setMetricExporter(metricExporter)
+            .build();
+
     // 4. Create a OpenTelemetry `Tracer` and use it for recording spans.
     Tracer tracer = OpenTelemetry.getTracerProvider().get("sample-app", "1.0");
+    Meter meter = OpenTelemetry.getMeterProvider().get("sample-app", "1.0");
+    LongCounter spanCounter =
+        meter
+            .longCounterBuilder("spanCounter")
+            .setUnit("one")
+            .setDescription("Counting all the spans")
+            .setMonotonic(true)
+            .build();
 
-    Span span = tracer.spanBuilder("testSpan").setSpanKind(Kind.INTERNAL).startSpan();
-    try (Scope scope = tracer.withSpan(span)) {
-      // do some work
-      Thread.sleep(1000);
-      span.end();
+    for (int i = 0; i < 100; i++) {
+      Span span = tracer.spanBuilder("testSpan").setSpanKind(Kind.INTERNAL).startSpan();
+      try (Scope scope = tracer.withSpan(span)) {
+        spanCounter.add(1, "spanName", "testSpan");
+        // do some work
+        Thread.sleep(500);
+        span.end();
+      }
     }
 
     // clean up so the JVM can exit. Note: the spanProcessor will flush any spans to the exporter
     // before it exits.
+    intervalMetricReader.shutdown();
     spanProcessor.shutdown();
-    Thread.sleep(10000);
   }
 }

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaDoubleCounterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaDoubleCounterTest.java
@@ -1,0 +1,29 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class DeltaDoubleCounterTest {
+
+  @Test
+  void testNoPrevious() throws Exception {
+    DeltaDoubleCounter deltaDoubleCounter = new DeltaDoubleCounter();
+    double result =
+        deltaDoubleCounter.delta(DoublePoint.create(100, 200, Collections.emptyMap(), 55.55d));
+
+    assertEquals(55.55d, result);
+  }
+
+  @Test
+  void testDiffVsPrevious() throws Exception {
+    DeltaDoubleCounter deltaDoubleCounter = new DeltaDoubleCounter();
+    deltaDoubleCounter.delta(DoublePoint.create(100, 200, Collections.emptyMap(), 55.55d));
+    double result =
+        deltaDoubleCounter.delta(DoublePoint.create(100, 200, Collections.emptyMap(), 77.77d));
+
+    assertEquals(22.22d, result);
+  }
+}

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaLongCounterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaLongCounterTest.java
@@ -1,0 +1,27 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+
+class DeltaLongCounterTest {
+
+  @Test
+  void testNoPrevious() throws Exception {
+    DeltaLongCounter deltaLongCounter = new DeltaLongCounter();
+    long result = deltaLongCounter.delta(LongPoint.create(100, 200, Collections.emptyMap(), 55));
+
+    assertEquals(55, result);
+  }
+
+  @Test
+  void testDiffVsPrevious() throws Exception {
+    DeltaLongCounter deltaLongCounter = new DeltaLongCounter();
+    deltaLongCounter.delta(LongPoint.create(100, 200, Collections.emptyMap(), 55));
+    long result = deltaLongCounter.delta(LongPoint.create(100, 200, Collections.emptyMap(), 77));
+
+    assertEquals(22, result);
+  }
+}

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
@@ -1,0 +1,174 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.metrics.Count;
+import com.newrelic.telemetry.metrics.Gauge;
+import com.newrelic.telemetry.metrics.Metric;
+import com.newrelic.telemetry.metrics.Summary;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.SummaryPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.ValueAtPercentile;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+
+class MetricPointAdapterTest {
+
+  @Test
+  void testLongPoint() throws Exception {
+    TimeTracker timeTracker = mock(TimeTracker.class);
+    when(timeTracker.getPreviousTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(9_000L));
+    MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
+
+    Attributes commonAttributes = new Attributes().put("service.name", "fooService");
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            Descriptor.create(
+                "metricName",
+                "metricDescription",
+                "units",
+                Type.MONOTONIC_LONG,
+                singletonMap("commonKey", "commonValue")),
+            Type.MONOTONIC_LONG,
+            commonAttributes,
+            LongPoint.create(
+                100,
+                TimeUnit.MILLISECONDS.toNanos(10_000L),
+                singletonMap("specificKey", "specificValue"),
+                123L));
+
+    Attributes expectedAttributes =
+        new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
+    assertEquals(
+        singleton(new Count("metricName", 123L, 9_000L, 10_000L, expectedAttributes)), result);
+  }
+
+  @Test
+  void testLongPoint_nonMonotonic() throws Exception {
+    TimeTracker timeTracker = mock(TimeTracker.class);
+    MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
+
+    Attributes commonAttributes = new Attributes().put("service.name", "fooService");
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            Descriptor.create(
+                "metricName",
+                "metricDescription",
+                "units",
+                Type.NON_MONOTONIC_LONG,
+                singletonMap("commonKey", "commonValue")),
+            Type.NON_MONOTONIC_LONG,
+            commonAttributes,
+            LongPoint.create(
+                100,
+                TimeUnit.MILLISECONDS.toNanos(10_000L),
+                singletonMap("specificKey", "specificValue"),
+                123L));
+
+    Attributes expectedAttributes =
+        new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
+    assertEquals(singleton(new Gauge("metricName", 123L, 10_000L, expectedAttributes)), result);
+  }
+
+  @Test
+  void testDoublePoint() throws Exception {
+    TimeTracker timeTracker = mock(TimeTracker.class);
+    when(timeTracker.getPreviousTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(9_000L));
+    MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
+
+    Attributes commonAttributes = new Attributes().put("service.name", "fooService");
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            Descriptor.create(
+                "metricName",
+                "metricDescription",
+                "units",
+                Type.MONOTONIC_DOUBLE,
+                singletonMap("commonKey", "commonValue")),
+            Type.MONOTONIC_DOUBLE,
+            commonAttributes,
+            DoublePoint.create(
+                100,
+                TimeUnit.MILLISECONDS.toNanos(10_000L),
+                singletonMap("specificKey", "specificValue"),
+                123.55d));
+
+    Attributes expectedAttributes =
+        new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
+    assertEquals(
+        singleton(new Count("metricName", 123.55d, 9_000L, 10_000L, expectedAttributes)), result);
+  }
+
+  @Test
+  void testDoublePoint_nonMonotonic() throws Exception {
+    TimeTracker timeTracker = mock(TimeTracker.class);
+    MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
+
+    Attributes commonAttributes = new Attributes().put("service.name", "fooService");
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            Descriptor.create(
+                "metricName",
+                "metricDescription",
+                "units",
+                Type.NON_MONOTONIC_DOUBLE,
+                singletonMap("commonKey", "commonValue")),
+            Type.NON_MONOTONIC_DOUBLE,
+            commonAttributes,
+            DoublePoint.create(
+                100,
+                TimeUnit.MILLISECONDS.toNanos(10_000L),
+                singletonMap("specificKey", "specificValue"),
+                123.55d));
+
+    Attributes expectedAttributes =
+        new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
+    assertEquals(singleton(new Gauge("metricName", 123.55d, 10_000L, expectedAttributes)), result);
+  }
+
+  @Test
+  void testSummaryPoint() throws Exception {
+    TimeTracker timeTracker = mock(TimeTracker.class);
+    when(timeTracker.getPreviousTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(9_000L));
+    MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
+
+    Attributes commonAttributes = new Attributes().put("service.name", "fooService");
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            Descriptor.create(
+                "metricName",
+                "metricDescription",
+                "units",
+                Type.SUMMARY,
+                singletonMap("commonKey", "commonValue")),
+            Type.SUMMARY,
+            commonAttributes,
+            SummaryPoint.create(
+                100,
+                TimeUnit.MILLISECONDS.toNanos(10_000L),
+                singletonMap("specificKey", "specificValue"),
+                200,
+                123.55d,
+                Arrays.asList(
+                    ValueAtPercentile.create(0.0, 5.5d),
+                    ValueAtPercentile.create(100.0, 100.01d))));
+
+    Attributes expectedAttributes =
+        new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
+    assertEquals(
+        singleton(
+            new Summary(
+                "metricName", 200, 123.55d, 5.5d, 100.01d, 9000L, 10000L, expectedAttributes)),
+        result);
+  }
+}

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
@@ -31,26 +31,30 @@ class MetricPointAdapterTest {
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
     Attributes commonAttributes = new Attributes().put("service.name", "fooService");
-    Collection<Metric> result =
-        metricPointAdapter.buildMetricsFromPoint(
-            Descriptor.create(
-                "metricName",
-                "metricDescription",
-                "units",
-                Type.MONOTONIC_LONG,
-                singletonMap("commonKey", "commonValue")),
+    Descriptor metricDescriptor =
+        Descriptor.create(
+            "metricName",
+            "metricDescription",
+            "units",
             Type.MONOTONIC_LONG,
-            commonAttributes,
-            LongPoint.create(
-                100,
-                TimeUnit.MILLISECONDS.toNanos(10_000L),
-                singletonMap("specificKey", "specificValue"),
-                123L));
+            singletonMap("commonKey", "commonValue"));
+
+    LongPoint longPoint =
+        LongPoint.create(
+            100,
+            TimeUnit.MILLISECONDS.toNanos(10_000L),
+            singletonMap("specificKey", "specificValue"),
+            123L);
 
     Attributes expectedAttributes =
         new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
-    assertEquals(
-        singleton(new Count("metricName", 123L, 9_000L, 10_000L, expectedAttributes)), result);
+    Count expectedMetric = new Count("metricName", 123L, 9_000L, 10_000L, expectedAttributes);
+
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            metricDescriptor, Type.MONOTONIC_LONG, commonAttributes, longPoint);
+
+    assertEquals(singleton(expectedMetric), result);
   }
 
   @Test
@@ -59,25 +63,30 @@ class MetricPointAdapterTest {
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
     Attributes commonAttributes = new Attributes().put("service.name", "fooService");
-    Collection<Metric> result =
-        metricPointAdapter.buildMetricsFromPoint(
-            Descriptor.create(
-                "metricName",
-                "metricDescription",
-                "units",
-                Type.NON_MONOTONIC_LONG,
-                singletonMap("commonKey", "commonValue")),
+    Descriptor metricDescriptor =
+        Descriptor.create(
+            "metricName",
+            "metricDescription",
+            "units",
             Type.NON_MONOTONIC_LONG,
-            commonAttributes,
-            LongPoint.create(
-                100,
-                TimeUnit.MILLISECONDS.toNanos(10_000L),
-                singletonMap("specificKey", "specificValue"),
-                123L));
+            singletonMap("commonKey", "commonValue"));
+
+    LongPoint longPoint =
+        LongPoint.create(
+            100,
+            TimeUnit.MILLISECONDS.toNanos(10_000L),
+            singletonMap("specificKey", "specificValue"),
+            123L);
 
     Attributes expectedAttributes =
         new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
-    assertEquals(singleton(new Gauge("metricName", 123L, 10_000L, expectedAttributes)), result);
+    Gauge expectedMetric = new Gauge("metricName", 123L, 10_000L, expectedAttributes);
+
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            metricDescriptor, Type.NON_MONOTONIC_LONG, commonAttributes, longPoint);
+
+    assertEquals(singleton(expectedMetric), result);
   }
 
   @Test
@@ -87,26 +96,29 @@ class MetricPointAdapterTest {
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
     Attributes commonAttributes = new Attributes().put("service.name", "fooService");
-    Collection<Metric> result =
-        metricPointAdapter.buildMetricsFromPoint(
-            Descriptor.create(
-                "metricName",
-                "metricDescription",
-                "units",
-                Type.MONOTONIC_DOUBLE,
-                singletonMap("commonKey", "commonValue")),
+    DoublePoint doublePoint =
+        DoublePoint.create(
+            100,
+            TimeUnit.MILLISECONDS.toNanos(10_000L),
+            singletonMap("specificKey", "specificValue"),
+            123.55d);
+    Descriptor metricDescriptor =
+        Descriptor.create(
+            "metricName",
+            "metricDescription",
+            "units",
             Type.MONOTONIC_DOUBLE,
-            commonAttributes,
-            DoublePoint.create(
-                100,
-                TimeUnit.MILLISECONDS.toNanos(10_000L),
-                singletonMap("specificKey", "specificValue"),
-                123.55d));
+            singletonMap("commonKey", "commonValue"));
 
     Attributes expectedAttributes =
         new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
-    assertEquals(
-        singleton(new Count("metricName", 123.55d, 9_000L, 10_000L, expectedAttributes)), result);
+    Count expectedMetric = new Count("metricName", 123.55d, 9_000L, 10_000L, expectedAttributes);
+
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            metricDescriptor, Type.MONOTONIC_DOUBLE, commonAttributes, doublePoint);
+
+    assertEquals(singleton(expectedMetric), result);
   }
 
   @Test
@@ -115,25 +127,29 @@ class MetricPointAdapterTest {
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
     Attributes commonAttributes = new Attributes().put("service.name", "fooService");
-    Collection<Metric> result =
-        metricPointAdapter.buildMetricsFromPoint(
-            Descriptor.create(
-                "metricName",
-                "metricDescription",
-                "units",
-                Type.NON_MONOTONIC_DOUBLE,
-                singletonMap("commonKey", "commonValue")),
+    Descriptor metricDescriptor =
+        Descriptor.create(
+            "metricName",
+            "metricDescription",
+            "units",
             Type.NON_MONOTONIC_DOUBLE,
-            commonAttributes,
-            DoublePoint.create(
-                100,
-                TimeUnit.MILLISECONDS.toNanos(10_000L),
-                singletonMap("specificKey", "specificValue"),
-                123.55d));
+            singletonMap("commonKey", "commonValue"));
+    DoublePoint doublePoint =
+        DoublePoint.create(
+            100,
+            TimeUnit.MILLISECONDS.toNanos(10_000L),
+            singletonMap("specificKey", "specificValue"),
+            123.55d);
 
     Attributes expectedAttributes =
         new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
-    assertEquals(singleton(new Gauge("metricName", 123.55d, 10_000L, expectedAttributes)), result);
+    Gauge expectedMetric = new Gauge("metricName", 123.55d, 10_000L, expectedAttributes);
+
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            metricDescriptor, Type.NON_MONOTONIC_DOUBLE, commonAttributes, doublePoint);
+
+    assertEquals(singleton(expectedMetric), result);
   }
 
   @Test
@@ -143,32 +159,34 @@ class MetricPointAdapterTest {
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
     Attributes commonAttributes = new Attributes().put("service.name", "fooService");
-    Collection<Metric> result =
-        metricPointAdapter.buildMetricsFromPoint(
-            Descriptor.create(
-                "metricName",
-                "metricDescription",
-                "units",
-                Type.SUMMARY,
-                singletonMap("commonKey", "commonValue")),
+    ValueAtPercentile min = ValueAtPercentile.create(0.0, 5.5d);
+    ValueAtPercentile max = ValueAtPercentile.create(100.0, 100.01d);
+    Descriptor metricDescriptor =
+        Descriptor.create(
+            "metricName",
+            "metricDescription",
+            "units",
             Type.SUMMARY,
-            commonAttributes,
-            SummaryPoint.create(
-                100,
-                TimeUnit.MILLISECONDS.toNanos(10_000L),
-                singletonMap("specificKey", "specificValue"),
-                200,
-                123.55d,
-                Arrays.asList(
-                    ValueAtPercentile.create(0.0, 5.5d),
-                    ValueAtPercentile.create(100.0, 100.01d))));
+            singletonMap("commonKey", "commonValue"));
+
+    SummaryPoint summary =
+        SummaryPoint.create(
+            100,
+            TimeUnit.MILLISECONDS.toNanos(10_000L),
+            singletonMap("specificKey", "specificValue"),
+            200,
+            123.55d,
+            Arrays.asList(min, max));
 
     Attributes expectedAttributes =
         new Attributes().put("service.name", "fooService").put("specificKey", "specificValue");
-    assertEquals(
-        singleton(
-            new Summary(
-                "metricName", 200, 123.55d, 5.5d, 100.01d, 9000L, 10000L, expectedAttributes)),
-        result);
+    Summary expectedMetric =
+        new Summary("metricName", 200, 123.55d, 5.5d, 100.01d, 9000L, 10000L, expectedAttributes);
+
+    Collection<Metric> result =
+        metricPointAdapter.buildMetricsFromPoint(
+            metricDescriptor, Type.SUMMARY, commonAttributes, summary);
+
+    assertEquals(singleton(expectedMetric), result);
   }
 }

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporterTest.java
@@ -1,0 +1,101 @@
+package com.newrelic.telemetry.opentelemetry.export;
+
+import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.TelemetryClient;
+import com.newrelic.telemetry.metrics.Count;
+import com.newrelic.telemetry.metrics.Gauge;
+import com.newrelic.telemetry.metrics.MetricBatch;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
+import io.opentelemetry.sdk.metrics.data.MetricData;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
+import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
+import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
+import io.opentelemetry.sdk.metrics.data.MetricData.Point;
+import io.opentelemetry.sdk.metrics.export.MetricExporter.ResultCode;
+import io.opentelemetry.sdk.resources.Resource;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+class NewRelicMetricExporterTest {
+
+  @Test
+  void testExport() throws Exception {
+    MetricPointAdapter metricPointAdapter = mock(MetricPointAdapter.class);
+    Attributes globalAttributes = new Attributes().put("globalKey", "globalValue");
+    TelemetryClient telemetryClient = mock(TelemetryClient.class);
+    TimeTracker timeTracker = mock(TimeTracker.class);
+    NewRelicMetricExporter newRelicMetricExporter =
+        new NewRelicMetricExporter(
+            telemetryClient, globalAttributes, timeTracker, metricPointAdapter);
+
+    Descriptor descriptor =
+        Descriptor.create(
+            "metricName",
+            "metricDescription",
+            "units",
+            Type.SUMMARY,
+            singletonMap("constantKey", "constantValue"));
+    Resource resource =
+        Resource.create(singletonMap("service.name", stringAttributeValue("myService")));
+    InstrumentationLibraryInfo libraryInfo =
+        InstrumentationLibraryInfo.create("instrumentationName", "1.0");
+    LongPoint point1 = LongPoint.create(1000, 2000, singletonMap("longLabel", "longValue"), 100L);
+    DoublePoint point2 =
+        DoublePoint.create(2001, 3001, singletonMap("doubleLabel", "doubleValue"), 100.33d);
+    Collection<Point> points = Arrays.asList(point1, point2);
+
+    Attributes updatedAttributes =
+        new Attributes()
+            .put("service.name", "myService")
+            .put("unit", "units")
+            .put("description", "metricDescription")
+            .put("instrumentation.version", "1.0")
+            .put("instrumentation.name", "instrumentationName")
+            .put("constantKey", "constantValue");
+
+    Count metric1 = new Count("count", 3d, 100, 200, new Attributes());
+    Gauge metric2 = new Gauge("gauge", 3d, 200, new Attributes());
+
+    when(metricPointAdapter.buildMetricsFromPoint(
+            descriptor, Type.SUMMARY, updatedAttributes, point1))
+        .thenReturn(singleton(metric1));
+    when(metricPointAdapter.buildMetricsFromPoint(
+            descriptor, Type.SUMMARY, updatedAttributes, point2))
+        .thenReturn(singleton(metric2));
+    ;
+    Attributes amendedGlobalAttributes =
+        globalAttributes
+            .copy()
+            .put("instrumentation.provider", "opentelemetry")
+            .put("collector.name", "newrelic-opentelemetry-exporter");
+
+    ResultCode result =
+        newRelicMetricExporter.export(
+            singleton(MetricData.create(descriptor, resource, libraryInfo, points)));
+
+    assertEquals(ResultCode.SUCCESS, result);
+
+    InOrder inOrder = inOrder(metricPointAdapter, timeTracker, telemetryClient);
+    inOrder
+        .verify(metricPointAdapter)
+        .buildMetricsFromPoint(descriptor, Type.SUMMARY, updatedAttributes, point1);
+    inOrder
+        .verify(metricPointAdapter)
+        .buildMetricsFromPoint(descriptor, Type.SUMMARY, updatedAttributes, point2);
+    inOrder.verify(timeTracker).tick();
+    inOrder
+        .verify(telemetryClient)
+        .sendBatch(new MetricBatch(Arrays.asList(metric1, metric2), amendedGlobalAttributes));
+  }
+}

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
@@ -9,8 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.when;
 
 import com.newrelic.telemetry.Attributes;
+import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.spans.SpanBatch;
-import com.newrelic.telemetry.spans.SpanBatchSender;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
@@ -33,7 +33,7 @@ class NewRelicSpanExporterTest {
   private final String hexTraceId = "000000000063d76f0000000037fe0393";
   private final TraceId traceId = TraceId.fromLowerBase16(hexTraceId, 0);
 
-  @Mock private SpanBatchSender sender;
+  @Mock private TelemetryClient sender;
   @Mock private SpanBatchAdapter adapter;
 
   @Test

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,1 +1,2 @@
-org.slf4j.simpleLogger.defaultLogLevel=debug
+org.slf4j.simpleLogger.defaultLogLevel=DEBUG
+org.slf4j.simpleLogger.log.com.newrelic.telemetry=DEBUG


### PR DESCRIPTION
This adds a Metric Exporter for OpenTelemetry. It currently targets build 0.3.0 of OpenTelemetry Java. 