### PR TITLE
Update to OTel-Java 0.2.4 and NR Telemetry SDK 0.4.0.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,8 +39,8 @@ googleJavaFormat {
 }
 
 dependencies {
-    api("com.newrelic.telemetry:telemetry:0.3.1")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.2.0")
+    api("com.newrelic.telemetry:telemetry:0.4.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.2.4")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.3.1")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -11,7 +11,7 @@ import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
 import com.newrelic.telemetry.spans.SpanBatchSenderBuilder;
-import io.opentelemetry.sdk.trace.SpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.MalformedURLException;
 import java.net.URI;

--- a/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -11,10 +11,10 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.Span.SpanBuilder;
 import com.newrelic.telemetry.spans.SpanBatch;
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
 import java.util.Collection;
@@ -75,13 +75,13 @@ class SpanBatchAdapter {
       SpanData span, Attributes attributes) {
     InstrumentationLibraryInfo instrumentationLibraryInfo = span.getInstrumentationLibraryInfo();
     if (instrumentationLibraryInfo != null) {
-      if (instrumentationLibraryInfo.name() != null
-          && !instrumentationLibraryInfo.name().isEmpty()) {
-        attributes.put("instrumentation.name", instrumentationLibraryInfo.name());
+      if (instrumentationLibraryInfo.getName() != null
+          && !instrumentationLibraryInfo.getName().isEmpty()) {
+        attributes.put("instrumentation.name", instrumentationLibraryInfo.getName());
       }
-      if (instrumentationLibraryInfo.version() != null
-          && !instrumentationLibraryInfo.version().isEmpty()) {
-        attributes.put("instrumentation.version", instrumentationLibraryInfo.version());
+      if (instrumentationLibraryInfo.getVersion() != null
+          && !instrumentationLibraryInfo.getVersion().isEmpty()) {
+        attributes.put("instrumentation.version", instrumentationLibraryInfo.getVersion());
       }
     }
     return attributes;
@@ -89,6 +89,11 @@ class SpanBatchAdapter {
 
   private static Attributes createIntrinsicAttributes(SpanData span, Attributes attributes) {
     Map<String, AttributeValue> originalAttributes = span.getAttributes();
+    return addAttributes(attributes, originalAttributes);
+  }
+
+  private static Attributes addAttributes(
+      Attributes attributes, Map<String, AttributeValue> originalAttributes) {
     originalAttributes.forEach(
         (key, value) -> {
           switch (value.getType()) {
@@ -120,8 +125,8 @@ class SpanBatchAdapter {
   private static Attributes addResourceAttributes(SpanData span, Attributes attributes) {
     Resource resource = span.getResource();
     if (resource != null) {
-      Map<String, String> labelsMap = resource.getLabels();
-      labelsMap.forEach(attributes::put);
+      Map<String, AttributeValue> labelsMap = resource.getAttributes();
+      addAttributes(attributes, labelsMap);
     }
     return attributes;
   }

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -28,10 +28,10 @@ public class BasicExample {
     BatchSpansProcessor spanProcessor = BatchSpansProcessor.newBuilder(exporter).build();
 
     // 3. Add the span processor to the default TracerSdkFactory
-    OpenTelemetrySdk.getTracerFactory().addSpanProcessor(spanProcessor);
+    OpenTelemetrySdk.getTracerProvider().addSpanProcessor(spanProcessor);
 
     // 4. Create a OpenTelemetry `Tracer` and use it for recording spans.
-    Tracer tracer = OpenTelemetry.getTracerFactory().get("sample-app", "1.0");
+    Tracer tracer = OpenTelemetry.getTracerProvider().get("sample-app", "1.0");
 
     Span span = tracer.spanBuilder("testSpan").setSpanKind(Kind.INTERNAL).startSpan();
     try (Scope scope = tracer.withSpan(span)) {

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -27,7 +27,7 @@ public class BasicExample {
     // 2. Build the OpenTelemetry `BatchSpansProcessor` with the `NewRelicSpanExporter`
     BatchSpansProcessor spanProcessor = BatchSpansProcessor.newBuilder(exporter).build();
 
-    // 3. Add the span processor to the default TracerSdkFactory
+    // 3. Add the span processor to the TracerProvider from the SDK
     OpenTelemetrySdk.getTracerProvider().addSpanProcessor(spanProcessor);
 
     // 4. Create a OpenTelemetry `Tracer` and use it for recording spans.

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
@@ -12,7 +12,7 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.SpanBatch;
 import com.newrelic.telemetry.spans.SpanBatchSender;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.SpanData;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -59,6 +59,7 @@ class NewRelicSpanExporterTest {
         .setStatus(Status.OK)
         .setStartEpochNanos(456_001_000L)
         .setEndEpochNanos(456_001_100L)
+        .setHasEnded(true)
         .build();
   }
 }

--- a/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
+++ b/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
@@ -12,10 +12,10 @@ import static org.mockito.Mockito.when;
 import com.google.common.collect.ImmutableMap;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.SpanBatch;
+import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
-import io.opentelemetry.sdk.trace.InstrumentationLibraryInfo;
-import io.opentelemetry.sdk.trace.SpanData;
-import io.opentelemetry.trace.AttributeValue;
+import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -35,8 +35,8 @@ class SpanBatchAdapterTest {
   @Test
   void testSendBatchWithSingleSpan() {
     InstrumentationLibraryInfo instrumentationLibraryInfo = mock(InstrumentationLibraryInfo.class);
-    when(instrumentationLibraryInfo.name()).thenReturn("jetty-server");
-    when(instrumentationLibraryInfo.version()).thenReturn("3.14.159");
+    when(instrumentationLibraryInfo.getName()).thenReturn("jetty-server");
+    when(instrumentationLibraryInfo.getVersion()).thenReturn("3.14.159");
 
     Attributes expectedAttributes =
         new Attributes()
@@ -62,7 +62,13 @@ class SpanBatchAdapterTest {
 
     SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes());
 
-    Resource inputResource = Resource.create(ImmutableMap.of("host", "bar", "datacenter", "boo"));
+    Resource inputResource =
+        Resource.create(
+            ImmutableMap.of(
+                "host",
+                AttributeValue.stringAttributeValue("bar"),
+                "datacenter",
+                AttributeValue.stringAttributeValue("boo")));
     SpanData inputSpan =
         SpanData.newBuilder()
             .setTraceId(traceId)
@@ -75,6 +81,7 @@ class SpanBatchAdapterTest {
             .setResource(inputResource)
             .setInstrumentationLibraryInfo(instrumentationLibraryInfo)
             .setKind(Kind.SERVER)
+            .setHasEnded(true)
             .build();
 
     SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
@@ -125,6 +132,7 @@ class SpanBatchAdapterTest {
             .setName("spanName")
             .setKind(Kind.SERVER)
             .setStatus(Status.OK)
+            .setHasEnded(true)
             .build();
 
     SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
@@ -144,6 +152,7 @@ class SpanBatchAdapterTest {
             .setName("spanName")
             .setKind(Kind.SERVER)
             .setStatus(Status.OK)
+            .setHasEnded(true)
             .build();
     SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));
 
@@ -179,6 +188,7 @@ class SpanBatchAdapterTest {
             .setStatus(Status.CANCELLED.withDescription("it's broken"))
             .setName("spanName")
             .setKind(Kind.SERVER)
+            .setHasEnded(true)
             .build();
 
     SpanBatch result = testClass.adaptToSpanBatch(Collections.singletonList(inputSpan));


### PR DESCRIPTION
 0.2.4 is very close to what will be released as "beta" with 0.3.0, so it seems like a good spot to sync up with the changes to the SDK that are required.