### PR TITLE
New 'find and use data' section from docs team

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ in the test source code hierarchy that matches this example code. It should be c
 
 5. Find your spans in New Relic One: go to https://one.newrelic.com/ and select **Distributed Tracing**.
 
-## Find and use your data
+### Find and use your data
 
 For tips on how to find and query your data in New Relic, see [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data). 
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,15 @@
-# New Relic OpenTelemetry Span Exporter
+# New Relic OpenTelemetry span exporter
 An [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-java) reporter for sending spans to New Relic using the
 New Relic Java Telemetry SDK.
 For the juicy details on how OpenTelemetry spans are mapped to New Relic spans, see documentation in
-[Our Exporter Specifications Documentation](https://github.com/newrelic/newrelic-exporter-specs)
+[Our exporter specifications documentation](https://github.com/newrelic/newrelic-exporter-specs)
 
-### How To Use
+### How to use
 
-In order to send spans to New Relic, you will need an Insights Insert API Key.
-Please see [New Relic Api Keys](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#)
-for more information.
+To send spans to New Relic, you will need an [Insights Insert API Key](https://docs.newrelic.com/docs/insights/insights-data-sources/custom-data/introduction-event-api#).
 
 Note: There is an example [BasicExample.java](src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java)  
-in the test source code hierarchy that matches this example code. It should be considered
-as the canonical code for this example, since OpenTelemetry internal SDK APIs are still a work in progress.
+in the test source code hierarchy that matches this example code. It should be considered as the canonical code for this example, since OpenTelemetry internal SDK APIs are still a work in progress.
 
 1. Create a `NewRelicSpanExporter`
 ```
@@ -44,7 +41,15 @@ as the canonical code for this example, since OpenTelemetry internal SDK APIs ar
     }
 ```
 
-5. Find your spans in New Relic One Distributed Tracing UI. https://one.newrelic.com/
+5. Find your spans in New Relic One: go to https://one.newrelic.com/ and select **Distributed Tracing**.
+
+## Find and use your data
+
+For tips on how to find and query your data in New Relic, see [Find trace/span data](https://docs.newrelic.com/docs/understand-dependencies/distributed-tracing/trace-api/introduction-trace-api#view-data). 
+
+For general querying information, see:
+- [Query New Relic data](https://docs.newrelic.com/docs/using-new-relic/data/understand-data/query-new-relic-data)
+- [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql)
 
 
 ### Gradle
@@ -67,7 +72,7 @@ implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.3.2")
 
 ### Building
 CI builds are run on Azure Pipelines:
-[![Build Status](https://dev.azure.com/NRAzurePipelines/Java%20CI/_apis/build/status/PR%20Build%20for%20OpenTelemetry%20Exporters?branchName=master)](https://dev.azure.com/NRAzurePipelines/Java%20CI/_build/latest?definitionId=11&branchName=master)
+[![Build status](https://dev.azure.com/NRAzurePipelines/Java%20CI/_apis/build/status/PR%20Build%20for%20OpenTelemetry%20Exporters?branchName=master)](https://dev.azure.com/NRAzurePipelines/Java%20CI/_build/latest?definitionId=11&branchName=master)
 
 The project uses gradle 5 for building, and the gradle wrapper is provided.
 
@@ -76,4 +81,4 @@ To compile, run the tests and build the jar:
 `$ ./gradlew build`
 
 ### Contributing
-Full details are available in our [CONTRIBUTING.md file](CONTRIBUTING.md). We'd love to get your contributions to improve the New Relic OpenTelemetry Exporter! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project. To execute our corporate CLA, which is required if your contribution is on behalf of a company, or if you have any questions, please drop us an email at open-source@newrelic.com.
+Full details are available in our [CONTRIBUTING.md file](CONTRIBUTING.md). We'd love to get your contributions to improve the New Relic OpenTelemetry exporter! Keep in mind when you submit your pull request, you'll need to sign the CLA via the click-through using CLA-Assistant. You only have to sign the CLA one time per project. To execute our corporate CLA, which is required if your contribution is on behalf of a company, or if you have any questions, please drop us an email at open-source@newrelic.com.


### PR DESCRIPTION
This is from Zach Elwood on NR docs team. 

This PR is to add a ‘how to find data’ section so that customers can find the data they send. I’ve included what I think are the applicable data types [spans] but let me know if there are other data types reported by this exporter. If you think this exporter will change to send other types of data in future, keep in mind it will be important to update this repo with link to that data type.

Also changed some title case to sentence case; small thing but we want headings to be sentence case and not title case, so just something to keep in mind when creating new content. 