### PR TITLE
Add OpenTelemetry user-agent string to exporters.

### DIFF
--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * The NewRelicMetricExporter takes a collection of MetricData objects, converts them into a New
@@ -32,6 +33,13 @@ public class NewRelicMetricExporter implements MetricExporter {
   private final TelemetryClient telemetryClient;
   private final TimeTracker timeTracker;
   private final MetricPointAdapter metricPointAdapter;
+  private static final String implementationVersion;
+
+  static {
+    Package thisPackage = NewRelicMetricExporter.class.getPackage();
+    implementationVersion =
+        Optional.ofNullable(thisPackage.getImplementationVersion()).orElse("UnknownVersion");
+  }
 
   /**
    * Create a metric exporter with the given components.
@@ -194,6 +202,7 @@ public class NewRelicMetricExporter implements MetricExporter {
             telemetryClient, commonAttributes, timeTracker, new MetricPointAdapter(timeTracker));
       }
       MetricBatchSenderBuilder builder = SimpleMetricBatchSender.builder(apiKey);
+      builder.secondaryUserAgent("NewRelic-OpenTelemetry-Exporter", implementationVersion);
       if (enableAuditLogging) {
         builder.enableAuditLogging();
       }

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * The NewRelicMetricExporter takes a collection of MetricData objects, converts them into a New
@@ -33,13 +32,6 @@ public class NewRelicMetricExporter implements MetricExporter {
   private final TelemetryClient telemetryClient;
   private final TimeTracker timeTracker;
   private final MetricPointAdapter metricPointAdapter;
-  private static final String implementationVersion;
-
-  static {
-    Package thisPackage = NewRelicMetricExporter.class.getPackage();
-    implementationVersion =
-        Optional.ofNullable(thisPackage.getImplementationVersion()).orElse("UnknownVersion");
-  }
 
   /**
    * Create a metric exporter with the given components.
@@ -202,7 +194,7 @@ public class NewRelicMetricExporter implements MetricExporter {
             telemetryClient, commonAttributes, timeTracker, new MetricPointAdapter(timeTracker));
       }
       MetricBatchSenderBuilder builder = SimpleMetricBatchSender.builder(apiKey);
-      builder.secondaryUserAgent("NewRelic-OpenTelemetry-Exporter", implementationVersion);
+      builder.secondaryUserAgent("NewRelic-OpenTelemetry-Exporter", null);
       if (enableAuditLogging) {
         builder.enableAuditLogging();
       }

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -15,7 +15,6 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
-import java.util.Optional;
 
 /**
  * The NewRelicSpanExporter takes a list of Span objects, converts them into a New Relic SpanBatch
@@ -27,13 +26,6 @@ public class NewRelicSpanExporter implements SpanExporter {
 
   private final SpanBatchAdapter adapter;
   private final TelemetryClient telemetryClient;
-  private static final String implementationVersion;
-
-  static {
-    Package thisPackage = NewRelicSpanExporter.class.getPackage();
-    implementationVersion =
-        Optional.ofNullable(thisPackage.getImplementationVersion()).orElse("UnknownVersion");
-  }
 
   /**
    * Constructor for the NewRelicSpanExporter.
@@ -162,7 +154,7 @@ public class NewRelicSpanExporter implements SpanExporter {
         return new NewRelicSpanExporter(new SpanBatchAdapter(commonAttributes), telemetryClient);
       }
       SpanBatchSenderBuilder builder = SimpleSpanBatchSender.builder(apiKey);
-      builder.secondaryUserAgent("NewRelic-OpenTelemetry-Exporter", implementationVersion);
+      builder.secondaryUserAgent("NewRelic-OpenTelemetry-Exporter", null);
       if (enableAuditLogging) {
         builder.enableAuditLogging();
       }

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -15,6 +15,7 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * The NewRelicSpanExporter takes a list of Span objects, converts them into a New Relic SpanBatch
@@ -26,6 +27,13 @@ public class NewRelicSpanExporter implements SpanExporter {
 
   private final SpanBatchAdapter adapter;
   private final TelemetryClient telemetryClient;
+  private static final String implementationVersion;
+
+  static {
+    Package thisPackage = NewRelicSpanExporter.class.getPackage();
+    implementationVersion =
+        Optional.ofNullable(thisPackage.getImplementationVersion()).orElse("UnknownVersion");
+  }
 
   /**
    * Constructor for the NewRelicSpanExporter.
@@ -154,6 +162,7 @@ public class NewRelicSpanExporter implements SpanExporter {
         return new NewRelicSpanExporter(new SpanBatchAdapter(commonAttributes), telemetryClient);
       }
       SpanBatchSenderBuilder builder = SimpleSpanBatchSender.builder(apiKey);
+      builder.secondaryUserAgent("NewRelic-OpenTelemetry-Exporter", implementationVersion);
       if (enableAuditLogging) {
         builder.enableAuditLogging();
       }


### PR DESCRIPTION
This PR adds secondary user agent strings for span and metric OpenTelemetry exporters.