### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ in the test source code hierarchy that matches this example code. It should be c
 
 #### For spans:
 
+Important: If you are using [auto-instrumentation](#auto-instrumentation), you should skip the configuration of the SDK, and go right to step 4.
+
 1. Create a `NewRelicSpanExporter`
 ```java
     NewRelicSpanExporter exporter = NewRelicSpanExporter.newBuilder()


### PR DESCRIPTION
Add clarification that you shouldn't configure the SDK if you're using the auto-instrumentation agent.

Resolves #50 