### PR TITLE
Update to work with OpenTelemetry-Java 0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Important: If you are using [auto-instrumentation](#auto-instrumentation), you s
 
 2. Build the OpenTelemetry `BatchSpansProcessor` with the `NewRelicSpanExporter` 
 ```java
-    BatchSpansProcessor spanProcessor = BatchSpansProcessor.create(exporter);
+    BatchSpanProcessor spanProcessor = BatchSpanProcessor.newBuilder(exporter).build();
 ```
 
 3. Add the span processor to the default TracerSdkProvider

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     api("com.newrelic.telemetry:telemetry:0.6.0")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.4.1")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.5.0")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.6.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -55,7 +55,7 @@ public class BasicExample {
             .commonAttributes(serviceAttributes)
             .build();
 
-    // 3. Build the OpenTelemetry `BatchSpansProcessor` with the `NewRelicSpanExporter`
+    // 3. Build the OpenTelemetry `BatchSpanProcessor` with the `NewRelicSpanExporter`
     BatchSpanProcessor spanProcessor = BatchSpanProcessor.newBuilder(exporter).build();
 
     // 4. Add the span processor to the TracerProvider from the SDK

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -14,13 +14,13 @@ import com.newrelic.telemetry.spans.SpanBatchSender;
 import io.opentelemetry.OpenTelemetry;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.metrics.LongCounter;
-import io.opentelemetry.metrics.LongMeasure;
-import io.opentelemetry.metrics.LongMeasure.BoundLongMeasure;
+import io.opentelemetry.metrics.LongValueRecorder;
+import io.opentelemetry.metrics.LongValueRecorder.BoundLongValueRecorder;
 import io.opentelemetry.metrics.Meter;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import io.opentelemetry.sdk.trace.export.BatchSpansProcessor;
+import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import io.opentelemetry.trace.Span;
 import io.opentelemetry.trace.Span.Kind;
@@ -56,7 +56,7 @@ public class BasicExample {
             .build();
 
     // 3. Build the OpenTelemetry `BatchSpansProcessor` with the `NewRelicSpanExporter`
-    BatchSpansProcessor spanProcessor = BatchSpansProcessor.create(exporter);
+    BatchSpanProcessor spanProcessor = BatchSpanProcessor.newBuilder(exporter).build();
 
     // 4. Add the span processor to the TracerProvider from the SDK
     OpenTelemetrySdk.getTracerProvider().addSpanProcessor(spanProcessor);
@@ -84,20 +84,18 @@ public class BasicExample {
             .longCounterBuilder("spanCounter")
             .setUnit("one")
             .setDescription("Counting all the spans")
-            .setMonotonic(true)
             .build();
 
     // 8. Here's an example of a measure.
-    LongMeasure spanTimer =
+    LongValueRecorder spanTimer =
         meter
-            .longMeasureBuilder("spanTimer")
+            .longValueRecorderBuilder("spanTimer")
             .setUnit("ms")
             .setDescription("How long the spans take")
-            .setAbsolute(true)
             .build();
 
     // 9. Optionally, you can pre-bind a set of labels, rather than passing them in every time.
-    BoundLongMeasure boundTimer = spanTimer.bind("spanName", "testSpan");
+    BoundLongValueRecorder boundTimer = spanTimer.bind("spanName", "testSpan");
 
     // 10. use these to instrument some work
     doSomeSimulatedWork(tracer, spanCounter, boundTimer);
@@ -128,7 +126,7 @@ public class BasicExample {
   }
 
   private static void doSomeSimulatedWork(
-      Tracer tracer, LongCounter spanCounter, BoundLongMeasure boundTimer)
+      Tracer tracer, LongCounter spanCounter, BoundLongValueRecorder boundTimer)
       throws InterruptedException {
     Random random = new Random();
     for (int i = 0; i < 100; i++) {

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
@@ -13,6 +13,7 @@ import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.spans.SpanBatch;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.sdk.trace.export.SpanExporter.ResultCode;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
@@ -50,7 +51,7 @@ class NewRelicSpanExporterTest {
   }
 
   private SpanData createMinimalSpanData() {
-    return SpanData.newBuilder()
+    return TestSpanData.newBuilder()
         .setTraceId(traceId)
         .setSpanId(spanId)
         .setResource(Resource.create(Collections.emptyMap()))

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
@@ -21,6 +21,7 @@ import io.opentelemetry.common.AttributeValue;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.test.TestSpanData;
 import io.opentelemetry.trace.Span.Kind;
 import io.opentelemetry.trace.SpanId;
 import io.opentelemetry.trace.Status;
@@ -76,7 +77,7 @@ class SpanBatchAdapterTest {
                 "datacenter",
                 AttributeValue.stringAttributeValue("boo")));
     SpanData inputSpan =
-        SpanData.newBuilder()
+        TestSpanData.newBuilder()
             .setTraceId(traceId)
             .setSpanId(spanId)
             .setStartEpochNanos(1_000_456_001_000L)
@@ -121,7 +122,7 @@ class SpanBatchAdapterTest {
     SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes());
 
     SpanData inputSpan =
-        SpanData.newBuilder()
+        TestSpanData.newBuilder()
             .setTraceId(traceId)
             .setSpanId(spanId)
             .setStartEpochNanos(1_000_456_001_000L)
@@ -151,7 +152,7 @@ class SpanBatchAdapterTest {
     SpanBatchAdapter testClass = new SpanBatchAdapter(new Attributes());
 
     SpanData inputSpan =
-        SpanData.newBuilder()
+        TestSpanData.newBuilder()
             .setTraceId(traceId)
             .setSpanId(spanId)
             .setStartEpochNanos(456_001_000L)
@@ -219,8 +220,8 @@ class SpanBatchAdapterTest {
   }
 
   private SpanData buildSpan(Status status) {
-    SpanData.Builder builder =
-        SpanData.newBuilder()
+    TestSpanData.Builder builder =
+        TestSpanData.newBuilder()
             .setTraceId(traceId)
             .setSpanId(spanId)
             .setStartEpochNanos(1_000_456_001_000L)


### PR DESCRIPTION
changes:
* SpanData is now an interface, with a TestSpanData implementation for testing
* Update example code for Metric Instrument refinements
* Rename of the BatchSpanProcessor, and re-introduction of the builder

Note: we'll want to update the auto-instrumentation support when that gets released, probably next week. This will include adding support for auto-configuration of metric export.