### PR TITLE
Update to support OpenTelemetry Java 0.6.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,20 +14,17 @@ apply(plugin = "signing")
 
 apply(plugin = "com.github.sherter.google-java-format")
 
-repositories {
-    maven("https://oss.jfrog.org/artifactory/oss-snapshot-local") {
-        mavenContent {
-            snapshotsOnly()
-        }
-    }
-}
-
 allprojects {
     group = "com.newrelic.telemetry"
     version = project.findProperty("releaseVersion") as String
     repositories {
         mavenCentral()
         maven(url = "https://oss.sonatype.org/content/repositories/snapshots")
+        maven("https://oss.jfrog.org/artifactory/oss-snapshot-local") {
+            mavenContent {
+                snapshotsOnly()
+            }
+        }
     }
     tasks.withType<Test> {
         useJUnitPlatform()

--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -8,7 +8,7 @@ apply(plugin = "com.github.johnrengelman.shadow")
 
 dependencies {
     api(project(":opentelemetry-exporters-newrelic"))
-    implementation("io.opentelemetry:opentelemetry-sdk-contrib-auto-config:0.6.0-SNAPSHOT")
+    implementation("io.opentelemetry:opentelemetry-sdk-extension-auto-config:0.6.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")

--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -8,7 +8,7 @@ apply(plugin = "com.github.johnrengelman.shadow")
 
 dependencies {
     api(project(":opentelemetry-exporters-newrelic"))
-    implementation("io.opentelemetry:opentelemetry-sdk-contrib-auto-config:0.5.0")
+    implementation("io.opentelemetry:opentelemetry-sdk-contrib-auto-config:0.6.0-SNAPSHOT")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
@@ -31,7 +31,7 @@ public class NewRelicConfiguration {
     return config.getString(NEW_RELIC_SERVICE_NAME, DEFAULT_NEW_RELIC_SERVICE_NAME);
   }
 
-  static boolean isNotBlank(String s) {
+  static boolean isSpecified(String s) {
     return s != null && !s.isEmpty();
   }
 }

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
@@ -30,4 +30,8 @@ public class NewRelicConfiguration {
   static String getServiceName(Config config) {
     return config.getString(NEW_RELIC_SERVICE_NAME, DEFAULT_NEW_RELIC_SERVICE_NAME);
   }
+
+  static boolean isNotBlank(String s) {
+    return s != null && !s.isEmpty();
+  }
 }

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
@@ -5,7 +5,7 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import io.opentelemetry.sdk.contrib.auto.config.Config;
+import io.opentelemetry.sdk.extensions.auto.config.Config;
 
 public class NewRelicConfiguration {
   static final String NEW_RELIC_API_KEY = "newrelic.api.key";

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
@@ -41,7 +41,7 @@ public class NewRelicMetricExporterFactory implements MetricExporterFactory {
     }
 
     String uriOverride = config.getString(NEW_RELIC_METRIC_URI_OVERRIDE, "");
-    if (isNotBlank(uriOverride)) {
+    if (isSpecified(uriOverride)) {
       builder.uriOverride(URI.create(uriOverride));
     }
 

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
@@ -12,8 +12,8 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter.Builder;
-import io.opentelemetry.sdk.contrib.auto.config.Config;
-import io.opentelemetry.sdk.contrib.auto.config.MetricExporterFactory;
+import io.opentelemetry.sdk.extensions.auto.config.Config;
+import io.opentelemetry.sdk.extensions.auto.config.MetricExporterFactory;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.URI;
 

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
@@ -6,12 +6,12 @@
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.*;
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_METRIC_URI_OVERRIDE;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter.Builder;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.sdk.contrib.auto.config.Config;
 import io.opentelemetry.sdk.contrib.auto.config.MetricExporterFactory;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
@@ -33,16 +33,15 @@ public class NewRelicMetricExporterFactory implements MetricExporterFactory {
   public MetricExporter fromConfig(Config config) {
     Builder builder =
         NewRelicMetricExporter.newBuilder()
-            .apiKey(NewRelicConfiguration.getApiKey(config))
-            .commonAttributes(
-                new Attributes().put(SERVICE_NAME, NewRelicConfiguration.getServiceName(config)));
+            .apiKey(getApiKey(config))
+            .commonAttributes(new Attributes().put(SERVICE_NAME, getServiceName(config)));
 
-    if (NewRelicConfiguration.shouldEnableAuditLogging(config)) {
+    if (shouldEnableAuditLogging(config)) {
       builder.enableAuditLogging();
     }
 
     String uriOverride = config.getString(NEW_RELIC_METRIC_URI_OVERRIDE, "");
-    if (!StringUtils.isNullOrEmpty(uriOverride)) {
+    if (isNotBlank(uriOverride)) {
       builder.uriOverride(URI.create(uriOverride));
     }
 

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
@@ -6,7 +6,7 @@
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.isNotBlank;
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.isSpecified;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
@@ -45,7 +45,7 @@ public class NewRelicSpanExporterFactory implements SpanExporterFactory {
     String deprecatedUriOverride = config.getString(NEW_RELIC_URI_OVERRIDE, "");
     String uriOverride =
         config.getString(NewRelicConfiguration.NEW_RELIC_TRACE_URI_OVERRIDE, deprecatedUriOverride);
-    if (isNotBlank(uriOverride)) {
+    if (isSpecified(uriOverride)) {
       newRelicSpanExporterBuilder.uriOverride(URI.create(uriOverride));
     }
 

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
@@ -10,8 +10,8 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
-import io.opentelemetry.sdk.contrib.auto.config.Config;
-import io.opentelemetry.sdk.contrib.auto.config.SpanExporterFactory;
+import io.opentelemetry.sdk.extensions.auto.config.Config;
+import io.opentelemetry.sdk.extensions.auto.config.SpanExporterFactory;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.URI;
 

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
@@ -6,10 +6,10 @@
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.isNotBlank;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
-import io.opentelemetry.internal.StringUtils;
 import io.opentelemetry.sdk.contrib.auto.config.Config;
 import io.opentelemetry.sdk.contrib.auto.config.SpanExporterFactory;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
@@ -45,7 +45,7 @@ public class NewRelicSpanExporterFactory implements SpanExporterFactory {
     String deprecatedUriOverride = config.getString(NEW_RELIC_URI_OVERRIDE, "");
     String uriOverride =
         config.getString(NewRelicConfiguration.NEW_RELIC_TRACE_URI_OVERRIDE, deprecatedUriOverride);
-    if (!StringUtils.isNullOrEmpty(uriOverride)) {
+    if (isNotBlank(uriOverride)) {
       newRelicSpanExporterBuilder.uriOverride(URI.create(uriOverride));
     }
 

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
@@ -12,7 +12,7 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.sdk.contrib.auto.config.Config;
+import io.opentelemetry.sdk.extensions.auto.config.Config;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
@@ -13,7 +13,7 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicSpanExpor
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.sdk.contrib.auto.config.Config;
+import io.opentelemetry.sdk.extensions.auto.config.Config;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies {
     val newRelicTelemetrySdkVersion = "0.6.1"
-    val openTelemetryVersion = "0.6.0-SNAPSHOT"
+    val openTelemetryVersion = "0.6.0"
 
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:$newRelicTelemetrySdkVersion")

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -1,9 +1,10 @@
 dependencies {
     val newRelicTelemetrySdkVersion = "0.6.1"
+    val openTelemetryVersion = "0.6.0-SNAPSHOT"
 
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:$newRelicTelemetrySdkVersion")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.5.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:$openTelemetryVersion")
 
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
@@ -9,10 +9,9 @@ import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUM
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUMENTATION_VERSION;
 
 import com.newrelic.telemetry.Attributes;
-import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
-import java.util.Map;
 
 public class AttributesSupport {
 
@@ -33,14 +32,13 @@ public class AttributesSupport {
 
   static Attributes addResourceAttributes(Attributes attributes, Resource resource) {
     if (resource != null) {
-      Map<String, AttributeValue> labelsMap = resource.getAttributes();
+      ReadableAttributes labelsMap = resource.getAttributes();
       putInAttributes(attributes, labelsMap);
     }
     return attributes;
   }
 
-  static void putInAttributes(
-      Attributes attributes, Map<String, AttributeValue> originalAttributes) {
+  static void putInAttributes(Attributes attributes, ReadableAttributes originalAttributes) {
     originalAttributes.forEach(
         (key, value) -> {
           switch (value.getType()) {

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -14,6 +14,7 @@ import com.newrelic.telemetry.metrics.Count;
 import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.Summary;
+import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
@@ -147,9 +148,9 @@ public class MetricPointAdapter {
   private static class Key {
     private final Descriptor descriptor;
     private final Type type;
-    private final Map<String, String> labels;
+    private final Labels labels;
 
-    public Key(Descriptor descriptor, Type type, Map<String, String> labels) {
+    public Key(Descriptor descriptor, Type type, Labels labels) {
       this.descriptor = descriptor;
       this.type = type;
       this.labels = labels;

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -19,7 +19,7 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.Span.SpanBuilder;
 import com.newrelic.telemetry.spans.SpanBatch;
-import io.opentelemetry.common.AttributeValue;
+import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import io.opentelemetry.trace.SpanId;
@@ -95,7 +95,7 @@ class SpanBatchAdapter {
   }
 
   private static Attributes createIntrinsicAttributes(SpanData span, Attributes attributes) {
-    Map<String, AttributeValue> originalAttributes = span.getAttributes();
+    ReadableAttributes originalAttributes = span.getAttributes();
     putInAttributes(attributes, originalAttributes);
     attributes.put(SPAN_KIND, span.getKind().name());
     return attributes;

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -17,6 +17,7 @@ import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
 import com.newrelic.telemetry.spans.SpanBatchSender;
 import io.opentelemetry.OpenTelemetry;
+import io.opentelemetry.common.Labels;
 import io.opentelemetry.context.Scope;
 import io.opentelemetry.metrics.LongCounter;
 import io.opentelemetry.metrics.LongValueRecorder;
@@ -100,7 +101,7 @@ public class BasicExample {
             .build();
 
     // 9. Optionally, you can pre-bind a set of labels, rather than passing them in every time.
-    BoundLongValueRecorder boundTimer = spanTimer.bind("spanName", "testSpan");
+    BoundLongValueRecorder boundTimer = spanTimer.bind(Labels.of("spanName", "testSpan"));
 
     // 10. use these to instrument some work
     doSomeSimulatedWork(tracer, spanCounter, boundTimer);
@@ -134,7 +135,7 @@ public class BasicExample {
       Tracer tracer, LongCounter spanCounter, BoundLongValueRecorder boundTimer)
       throws InterruptedException {
     Random random = new Random();
-    for (int i = 0; i < 100; i++) {
+    for (int i = 0; i < 10; i++) {
       long startTime = System.currentTimeMillis();
       Span span =
           tracer.spanBuilder("testSpan").setSpanKind(Kind.INTERNAL).setNoParent().startSpan();
@@ -143,7 +144,7 @@ public class BasicExample {
         if (markAsError) {
           span.setStatus(Status.INTERNAL.withDescription("internalError"));
         }
-        spanCounter.add(1, "spanName", "testSpan", "isItAnError", "" + markAsError);
+        spanCounter.add(1, Labels.of("spanName", "testSpan", "isItAnError", "" + markAsError));
         // do some work
         Thread.sleep(random.nextInt(1000));
         span.end();

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaDoubleCounterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaDoubleCounterTest.java
@@ -7,8 +7,8 @@ package com.newrelic.telemetry.opentelemetry.export;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DeltaDoubleCounterTest {
@@ -16,8 +16,7 @@ class DeltaDoubleCounterTest {
   @Test
   void testNoPrevious() throws Exception {
     DeltaDoubleCounter deltaDoubleCounter = new DeltaDoubleCounter();
-    double result =
-        deltaDoubleCounter.delta(DoublePoint.create(100, 200, Collections.emptyMap(), 55.55d));
+    double result = deltaDoubleCounter.delta(DoublePoint.create(100, 200, Labels.empty(), 55.55d));
 
     assertEquals(55.55d, result);
   }
@@ -25,9 +24,8 @@ class DeltaDoubleCounterTest {
   @Test
   void testDiffVsPrevious() throws Exception {
     DeltaDoubleCounter deltaDoubleCounter = new DeltaDoubleCounter();
-    deltaDoubleCounter.delta(DoublePoint.create(100, 200, Collections.emptyMap(), 55.55d));
-    double result =
-        deltaDoubleCounter.delta(DoublePoint.create(100, 200, Collections.emptyMap(), 77.77d));
+    deltaDoubleCounter.delta(DoublePoint.create(100, 200, Labels.empty(), 55.55d));
+    double result = deltaDoubleCounter.delta(DoublePoint.create(100, 200, Labels.empty(), 77.77d));
 
     assertEquals(22.22d, result);
   }

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaLongCounterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/DeltaLongCounterTest.java
@@ -7,8 +7,8 @@ package com.newrelic.telemetry.opentelemetry.export;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.LongPoint;
-import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 class DeltaLongCounterTest {
@@ -16,7 +16,7 @@ class DeltaLongCounterTest {
   @Test
   void testNoPrevious() throws Exception {
     DeltaLongCounter deltaLongCounter = new DeltaLongCounter();
-    long result = deltaLongCounter.delta(LongPoint.create(100, 200, Collections.emptyMap(), 55));
+    long result = deltaLongCounter.delta(LongPoint.create(100, 200, Labels.empty(), 55));
 
     assertEquals(55, result);
   }
@@ -24,8 +24,8 @@ class DeltaLongCounterTest {
   @Test
   void testDiffVsPrevious() throws Exception {
     DeltaLongCounter deltaLongCounter = new DeltaLongCounter();
-    deltaLongCounter.delta(LongPoint.create(100, 200, Collections.emptyMap(), 55));
-    long result = deltaLongCounter.delta(LongPoint.create(100, 200, Collections.emptyMap(), 77));
+    deltaLongCounter.delta(LongPoint.create(100, 200, Labels.empty(), 55));
+    long result = deltaLongCounter.delta(LongPoint.create(100, 200, Labels.empty(), 77));
 
     assertEquals(22, result);
   }

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
@@ -7,7 +7,6 @@ package com.newrelic.telemetry.opentelemetry.export;
 
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -17,6 +16,7 @@ import com.newrelic.telemetry.metrics.Count;
 import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.Summary;
+import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor.Type;
 import io.opentelemetry.sdk.metrics.data.MetricData.DoublePoint;
@@ -43,13 +43,13 @@ class MetricPointAdapterTest {
             "metricDescription",
             "units",
             Type.MONOTONIC_LONG,
-            singletonMap("commonKey", "commonValue"));
+            Labels.of("commonKey", "commonValue"));
 
     LongPoint longPoint =
         LongPoint.create(
             100,
             TimeUnit.MILLISECONDS.toNanos(10_000L),
-            singletonMap("specificKey", "specificValue"),
+            Labels.of("specificKey", "specificValue"),
             123L);
 
     Attributes expectedAttributes =
@@ -75,13 +75,13 @@ class MetricPointAdapterTest {
             "metricDescription",
             "units",
             Type.NON_MONOTONIC_LONG,
-            singletonMap("commonKey", "commonValue"));
+            Labels.of("commonKey", "commonValue"));
 
     LongPoint longPoint =
         LongPoint.create(
             100,
             TimeUnit.MILLISECONDS.toNanos(10_000L),
-            singletonMap("specificKey", "specificValue"),
+            Labels.of("specificKey", "specificValue"),
             123L);
 
     Attributes expectedAttributes =
@@ -106,7 +106,7 @@ class MetricPointAdapterTest {
         DoublePoint.create(
             100,
             TimeUnit.MILLISECONDS.toNanos(10_000L),
-            singletonMap("specificKey", "specificValue"),
+            Labels.of("specificKey", "specificValue"),
             123.55d);
     Descriptor metricDescriptor =
         Descriptor.create(
@@ -114,7 +114,7 @@ class MetricPointAdapterTest {
             "metricDescription",
             "units",
             Type.MONOTONIC_DOUBLE,
-            singletonMap("commonKey", "commonValue"));
+            Labels.of("commonKey", "commonValue"));
 
     Attributes expectedAttributes =
         new Attributes().put(SERVICE_NAME, "fooService").put("specificKey", "specificValue");
@@ -139,12 +139,12 @@ class MetricPointAdapterTest {
             "metricDescription",
             "units",
             Type.NON_MONOTONIC_DOUBLE,
-            singletonMap("commonKey", "commonValue"));
+            Labels.of("commonKey", "commonValue"));
     DoublePoint doublePoint =
         DoublePoint.create(
             100,
             TimeUnit.MILLISECONDS.toNanos(10_000L),
-            singletonMap("specificKey", "specificValue"),
+            Labels.of("specificKey", "specificValue"),
             123.55d);
 
     Attributes expectedAttributes =
@@ -173,13 +173,13 @@ class MetricPointAdapterTest {
             "metricDescription",
             "units",
             Type.SUMMARY,
-            singletonMap("commonKey", "commonValue"));
+            Labels.of("commonKey", "commonValue"));
 
     SummaryPoint summary =
         SummaryPoint.create(
             100,
             TimeUnit.MILLISECONDS.toNanos(10_000L),
-            singletonMap("specificKey", "specificValue"),
+            Labels.of("specificKey", "specificValue"),
             200,
             123.55d,
             Arrays.asList(min, max));

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporterTest.java
@@ -12,7 +12,6 @@ import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUM
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
 import static java.util.Collections.singleton;
-import static java.util.Collections.singletonMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -23,6 +22,7 @@ import com.newrelic.telemetry.TelemetryClient;
 import com.newrelic.telemetry.metrics.Count;
 import com.newrelic.telemetry.metrics.Gauge;
 import com.newrelic.telemetry.metrics.MetricBatch;
+import io.opentelemetry.common.Labels;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Descriptor;
@@ -40,7 +40,7 @@ import org.mockito.InOrder;
 class NewRelicMetricExporterTest {
 
   @Test
-  void testExport() throws Exception {
+  void testExport() {
     MetricPointAdapter metricPointAdapter = mock(MetricPointAdapter.class);
     Attributes globalAttributes = new Attributes().put("globalKey", "globalValue");
     TelemetryClient telemetryClient = mock(TelemetryClient.class);
@@ -55,14 +55,15 @@ class NewRelicMetricExporterTest {
             "metricDescription",
             "units",
             Type.SUMMARY,
-            singletonMap("constantKey", "constantValue"));
+            Labels.of("constantKey", "constantValue"));
     Resource resource =
-        Resource.create(singletonMap(SERVICE_NAME, stringAttributeValue("myService")));
+        Resource.create(
+            io.opentelemetry.common.Attributes.of(SERVICE_NAME, stringAttributeValue("myService")));
     InstrumentationLibraryInfo libraryInfo =
         InstrumentationLibraryInfo.create("instrumentationName", "1.0");
-    LongPoint point1 = LongPoint.create(1000, 2000, singletonMap("longLabel", "longValue"), 100L);
+    LongPoint point1 = LongPoint.create(1000, 2000, Labels.of("longLabel", "longValue"), 100L);
     DoublePoint point2 =
-        DoublePoint.create(2001, 3001, singletonMap("doubleLabel", "doubleValue"), 100.33d);
+        DoublePoint.create(2001, 3001, Labels.of("doubleLabel", "doubleValue"), 100.33d);
     Collection<Point> points = Arrays.asList(point1, point2);
 
     Attributes updatedAttributes =
@@ -83,7 +84,7 @@ class NewRelicMetricExporterTest {
     when(metricPointAdapter.buildMetricsFromPoint(
             descriptor, Type.SUMMARY, updatedAttributes, point2))
         .thenReturn(singleton(metric2));
-    ;
+
     Attributes amendedGlobalAttributes =
         globalAttributes
             .copy()

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporterTest.java
@@ -54,7 +54,7 @@ class NewRelicSpanExporterTest {
     return TestSpanData.newBuilder()
         .setTraceId(traceId)
         .setSpanId(spanId)
-        .setResource(Resource.create(Collections.emptyMap()))
+        .setResource(Resource.create(io.opentelemetry.common.Attributes.empty()))
         .setName("spanName")
         .setKind(Kind.SERVER)
         .setStatus(Status.OK)

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Sets;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.SpanBatch;
 import io.opentelemetry.common.AttributeValue;
@@ -30,7 +30,8 @@ import io.opentelemetry.trace.TraceId;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 class SpanBatchAdapterTest {
@@ -75,7 +76,7 @@ class SpanBatchAdapterTest {
 
     Resource inputResource =
         Resource.create(
-            ImmutableMap.of(
+            io.opentelemetry.common.Attributes.of(
                 "host",
                 AttributeValue.stringAttributeValue("bar"),
                 "datacenter",
@@ -108,7 +109,7 @@ class SpanBatchAdapterTest {
 
     Resource resource1 =
         Resource.create(
-            ImmutableMap.of(
+            io.opentelemetry.common.Attributes.of(
                 "host",
                 AttributeValue.stringAttributeValue("abcd"),
                 "datacenter",
@@ -116,7 +117,7 @@ class SpanBatchAdapterTest {
 
     Resource resource2 =
         Resource.create(
-            ImmutableMap.of(
+            io.opentelemetry.common.Attributes.of(
                 "host",
                 AttributeValue.stringAttributeValue("efgh"),
                 "datacenter",
@@ -167,8 +168,8 @@ class SpanBatchAdapterTest {
             .durationMs(1333.020111d)
             .attributes(expectedAttributes)
             .build();
-    List<SpanBatch> expected =
-        Arrays.asList(
+    Set<SpanBatch> expected =
+        Sets.newHashSet(
             new SpanBatch(
                 singletonList(outputSpan),
                 new Attributes()
@@ -188,7 +189,8 @@ class SpanBatchAdapterTest {
 
     Collection<SpanBatch> result =
         testClass.adaptToSpanBatches(Arrays.asList(inputSpan1, inputSpan2));
-    assertEquals(expected, result);
+    // wrap in a Set to get rid of any order dependency in the test.
+    assertEquals(expected, new HashSet<>(result));
   }
 
   @Test
@@ -224,7 +226,7 @@ class SpanBatchAdapterTest {
             .setStartEpochNanos(1_000_456_001_000L)
             .setEndEpochNanos(1_000_456_001_100L)
             .setAttributes(
-                ImmutableMap.of(
+                io.opentelemetry.common.Attributes.of(
                     "myBooleanKey",
                     AttributeValue.booleanAttributeValue(true),
                     "myIntKey",


### PR DESCRIPTION
This also includes a bit of cleanup in the creation of the MetricBatchSender, and a tiny bit of gradle cleanup as well.