### PR TITLE
Use the start timestamp on the SummaryPoint, rather than using the TimeTracker

### DIFF
--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -140,7 +140,7 @@ public class MetricPointAdapter {
             point.getSum(),
             min,
             max,
-            NANOSECONDS.toMillis(timeTracker.getPreviousTime()),
+            NANOSECONDS.toMillis(point.getStartEpochNanos()),
             NANOSECONDS.toMillis(point.getEpochNanos()),
             attributes));
   }

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapterTest.java
@@ -31,7 +31,7 @@ import org.junit.jupiter.api.Test;
 class MetricPointAdapterTest {
 
   @Test
-  void testLongPoint() throws Exception {
+  void testLongPoint() {
     TimeTracker timeTracker = mock(TimeTracker.class);
     when(timeTracker.getPreviousTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(9_000L));
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
@@ -64,7 +64,7 @@ class MetricPointAdapterTest {
   }
 
   @Test
-  void testLongPoint_nonMonotonic() throws Exception {
+  void testLongPoint_nonMonotonic() {
     TimeTracker timeTracker = mock(TimeTracker.class);
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
@@ -96,7 +96,7 @@ class MetricPointAdapterTest {
   }
 
   @Test
-  void testDoublePoint() throws Exception {
+  void testDoublePoint() {
     TimeTracker timeTracker = mock(TimeTracker.class);
     when(timeTracker.getPreviousTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(9_000L));
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
@@ -128,7 +128,7 @@ class MetricPointAdapterTest {
   }
 
   @Test
-  void testDoublePoint_nonMonotonic() throws Exception {
+  void testDoublePoint_nonMonotonic() {
     TimeTracker timeTracker = mock(TimeTracker.class);
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
 
@@ -159,7 +159,7 @@ class MetricPointAdapterTest {
   }
 
   @Test
-  void testSummaryPoint() throws Exception {
+  void testSummaryPoint() {
     TimeTracker timeTracker = mock(TimeTracker.class);
     when(timeTracker.getPreviousTime()).thenReturn(TimeUnit.MILLISECONDS.toNanos(9_000L));
     MetricPointAdapter metricPointAdapter = new MetricPointAdapter(timeTracker);
@@ -177,7 +177,7 @@ class MetricPointAdapterTest {
 
     SummaryPoint summary =
         SummaryPoint.create(
-            100,
+            TimeUnit.MILLISECONDS.toNanos(9_000L),
             TimeUnit.MILLISECONDS.toNanos(10_000L),
             Labels.of("specificKey", "specificValue"),
             200,


### PR DESCRIPTION
As of OpenTelemetry Java v0.6.0, the MinMaxSumCount aggregation properly populates the start timestamp, so we don't have to use the TimeTracker for this one.