### PR TITLE
Use version 0.7.0 of NR SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ repositories {
 ```
 
 ```
-implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.6.1")
+implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.7.0")
 implementation("io.opentelemetry:opentelemetry-sdk:0.6.0")
-implementation("com.newrelic.telemetry:telemetry-core:0.6.1")
-implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.6.1")
+implementation("com.newrelic.telemetry:telemetry-core:0.7.0")
+implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.7.0")
 ```
 
 ### Building

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    val newRelicTelemetrySdkVersion = "0.6.1"
+    val newRelicTelemetrySdkVersion = "0.7.0"
     val openTelemetryVersion = "0.6.0"
 
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")


### PR DESCRIPTION
- Use version 0.7.0 of the NR telemetry SDK, to fix issue with infinite tracing cell load shifting.
- After merging, it'd be great if we could cut a new release.