### PR TITLE
Add the service.instance.id to the metrics as well.

### DIFF
--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
@@ -12,8 +12,11 @@ import com.newrelic.telemetry.Attributes;
 import io.opentelemetry.common.ReadableAttributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
+import java.util.UUID;
 
 public class AttributesSupport {
+
+  static final String SERVICE_INSTANCE_ID = UUID.randomUUID().toString();
 
   static Attributes populateLibraryInfo(
       Attributes attributes, InstrumentationLibraryInfo instrumentationLibraryInfo) {

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicSpanExporter.java
@@ -18,7 +18,6 @@ import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.util.Collection;
-import java.util.UUID;
 
 /**
  * The NewRelicSpanExporter takes a list of Span objects, converts them into a New Relic SpanBatch
@@ -162,7 +161,7 @@ public class NewRelicSpanExporter implements SpanExporter {
      */
     public NewRelicSpanExporter build() {
       SpanBatchAdapter spanBatchAdapter =
-          new SpanBatchAdapter(commonAttributes, UUID.randomUUID().toString());
+          new SpanBatchAdapter(commonAttributes, AttributesSupport.SERVICE_INSTANCE_ID);
       if (telemetryClient != null) {
         return new NewRelicSpanExporter(spanBatchAdapter, telemetryClient);
       }

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporterTest.java
@@ -9,6 +9,7 @@ import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.COLLECT
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUMENTATION_NAME;
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUMENTATION_PROVIDER;
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUMENTATION_VERSION;
+import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_INSTANCE_ID;
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
 import static io.opentelemetry.common.AttributeValue.stringAttributeValue;
 import static java.util.Collections.singleton;
@@ -47,7 +48,7 @@ class NewRelicMetricExporterTest {
     TimeTracker timeTracker = mock(TimeTracker.class);
     NewRelicMetricExporter newRelicMetricExporter =
         new NewRelicMetricExporter(
-            telemetryClient, globalAttributes, timeTracker, metricPointAdapter);
+            telemetryClient, globalAttributes, timeTracker, metricPointAdapter, "instanceId");
 
     Descriptor descriptor =
         Descriptor.create(
@@ -89,7 +90,8 @@ class NewRelicMetricExporterTest {
         globalAttributes
             .copy()
             .put(INSTRUMENTATION_PROVIDER, "opentelemetry")
-            .put(COLLECTOR_NAME, "newrelic-opentelemetry-exporter");
+            .put(COLLECTOR_NAME, "newrelic-opentelemetry-exporter")
+            .put(SERVICE_INSTANCE_ID, "instanceId");
 
     ResultCode result =
         newRelicMetricExporter.export(


### PR DESCRIPTION
Note: This has a possibility of some cardinality issues. I'm aware of this, and we're going to give it a try, nonetheless. This will help link spans to the appropriate metrics, by instance.