### PR TITLE
Update the CHANGELOG and README for 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Coming soon
+
+## [0.8.0] - 2020-09-08
 - **BREAKING CHANGE** :: URI OVERRIDES THAT DO NOT HAVE A PATH COMPONENT WILL CAUSE YOUR SENDS TO FAIL.  Please specify a full URI including path component when doing a uriOverride.
 - Support for version 0.8.0 of OpenTelemetry Java
 
-## [0.7.0] - 2020-07-06
+## [0.7.0] - 2020-08-06
 - Support for OpenTelemetry Java 0.7.0
 - A simpler configuration and startup helper with `NewRelicExporters.java`
 

--- a/README.md
+++ b/README.md
@@ -188,8 +188,8 @@ repositories {
 ```
 
 ```
-implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.7.0")
-implementation("io.opentelemetry:opentelemetry-sdk:0.7.0")
+implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.8.0")
+implementation("io.opentelemetry:opentelemetry-sdk:0.8.0")
 implementation("com.newrelic.telemetry:telemetry-core:0.7.0")
 implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.7.0")
 ```


### PR DESCRIPTION
I don't know if this should be merged before or after cutting the release. 