### PR TITLE
Refactor: Leverage AutoService instead of handwritten META-INF files

### DIFF
--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -12,6 +12,8 @@ dependencies {
 //    jcenter()
     }
 
+    annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
+    api("com.google.auto.service:auto-service-annotations:1.0-rc7")
     api(project(":opentelemetry-exporters-newrelic"))
     implementation("io.opentelemetry.instrumentation.auto:opentelemetry-javaagent-tooling:0.8.0")
     implementation("io.opentelemetry:opentelemetry-sdk:0.8.0")

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
@@ -7,6 +7,7 @@ package com.newrelic.telemetry.opentelemetry.export.auto;
 
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
 
+import com.google.auto.service.AutoService;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter.Builder;
@@ -19,6 +20,7 @@ import java.net.URI;
  * A {@link MetricExporterFactory} that creates a {@link MetricExporter} that sends metrics to New
  * Relic.
  */
+@AutoService(MetricExporterFactory.class)
 public class NewRelicMetricExporterFactory implements MetricExporterFactory {
 
   /**

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
@@ -7,6 +7,7 @@ package com.newrelic.telemetry.opentelemetry.export.auto;
 
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE_NAME;
 
+import com.google.auto.service.AutoService;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
 import io.opentelemetry.javaagent.tooling.exporter.ExporterConfig;
@@ -17,6 +18,7 @@ import java.net.URI;
 /**
  * A {@link SpanExporterFactory} that creates a {@link SpanExporter} that sends spans to New Relic.
  */
+@AutoService(SpanExporterFactory.class)
 public class NewRelicSpanExporterFactory implements SpanExporterFactory {
 
   /**

--- a/opentelemetry-exporters-newrelic-auto/src/main/resources/META-INF/services/io.opentelemetry.javaagent.tooling.exporter.MetricExporterFactory
+++ b/opentelemetry-exporters-newrelic-auto/src/main/resources/META-INF/services/io.opentelemetry.javaagent.tooling.exporter.MetricExporterFactory
@@ -1,1 +1,0 @@
-com.newrelic.telemetry.opentelemetry.export.auto.NewRelicMetricExporterFactory

--- a/opentelemetry-exporters-newrelic-auto/src/main/resources/META-INF/services/io.opentelemetry.javaagent.tooling.exporter.SpanExporterFactory
+++ b/opentelemetry-exporters-newrelic-auto/src/main/resources/META-INF/services/io.opentelemetry.javaagent.tooling.exporter.SpanExporterFactory
@@ -1,1 +1,0 @@
-com.newrelic.telemetry.opentelemetry.export.auto.NewRelicSpanExporterFactory


### PR DESCRIPTION
# Motivation

Stumbled upon this repo and leveraged it _amply_ to be able to figure out how to setup Auto Exporters for OpenTelemetry Java. In doing so, noticed that there are handwritten `META-INF/service` files kicking around in here. Figured I'd like to give back in some small way for being able to build off of the work done herein!

## Testing

Verified locally both before and after, the structure of the UberJar's `META-INF/services` contains entries necessary for the [`TracerInstaller`](https://github.com/open-telemetry/opentelemetry-java-instrumentation/blob/master/javaagent-tooling/src/main/java/io/opentelemetry/javaagent/tooling/TracerInstaller.java#L65-L82) to function as expected.

<img width="1258" alt="Screen Shot 2020-09-17 at 10 55 50" src="https://user-images.githubusercontent.com/3885029/93496185-879a1a00-f8d4-11ea-8058-e01170a64ca1.png">


## Suggested Musical Pairing

https://soundcloud.com/slowthai/slowthai-james-blake-mount