### PR TITLE
update versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,15 @@ java -javaagent:path/to/opentelemetry-javaagent-<version>-all.jar \
      -Dotel.exporter.newrelic.service.name=best-service-ever \
      -jar myapp.jar
 ```
+:warning: If you encounter an error like this:
+
+```
+[main] WARN io.opentelemetry.auto.tooling.TracerInstaller - No span exporter found in opentelemetry-exporters-newrelic-auto-0.8.1.jar
+```
+
+Check our [release notes](https://github.com/newrelic/opentelemetry-exporter-java/releases) and verify the version of your `opentelemetry-exporter-newrelic-auto-<version>.jar` supports the version of `opentelemetry-javaagent-all.jar`.
+
+
 
 If you wish to turn on debug logging for the exporter running in the auto-instrumentation agent, use the following system property:
 ```

--- a/README.md
+++ b/README.md
@@ -175,9 +175,9 @@ repositories {
 
 ```
 implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.8.1")
-implementation("io.opentelemetry:opentelemetry-sdk:0.8.0")
-implementation("com.newrelic.telemetry:telemetry-core:0.7.0")
-implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.7.0")
+implementation("io.opentelemetry:opentelemetry-sdk:0.9.1")
+implementation("com.newrelic.telemetry:telemetry-core:0.9.0")
+implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.9.0")
 ```
 
 ## Getting Started

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -1,5 +1,5 @@
 dependencies {
-    val newRelicTelemetrySdkVersion = "0.7.0"
+    val newRelicTelemetrySdkVersion = "0.9.0"
     val openTelemetryVersion = "0.9.1"
 
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")


### PR DESCRIPTION
The revs the version of the telemetry core so the exporter can support Otel sdk `0.9.1` 