### PR TITLE
update to use 0.9.0 spi change from upstream

### DIFF
--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
     api("com.google.auto.service:auto-service-annotations:1.0-rc7")
     api(project(":opentelemetry-exporters-newrelic"))
-    implementation("io.opentelemetry.instrumentation.auto:opentelemetry-javaagent-tooling:0.8.0")
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.9.0")
     implementation("io.opentelemetry:opentelemetry-sdk:0.9.1")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicConfiguration.java
@@ -5,7 +5,7 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import io.opentelemetry.javaagent.tooling.exporter.ExporterConfig;
+import java.util.Properties;
 
 class NewRelicConfiguration {
   static final String NEW_RELIC_API_KEY = "newrelic.api.key";
@@ -19,26 +19,26 @@ class NewRelicConfiguration {
   // for any users who might still be using it.
   static final String NEW_RELIC_URI_OVERRIDE = "newrelic.uri.override";
 
-  private final ExporterConfig config;
+  private final Properties config;
 
-  NewRelicConfiguration(ExporterConfig config) {
+  NewRelicConfiguration(Properties config) {
     this.config = config;
   }
 
   String getApiKey() {
-    return config.getString(NEW_RELIC_API_KEY, "");
+    return config.getProperty(NEW_RELIC_API_KEY, "");
   }
 
   boolean shouldEnableAuditLogging() {
-    return config.getBoolean(NEW_RELIC_ENABLE_AUDIT_LOGGING, false);
+    return Boolean.parseBoolean(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false"));
   }
 
   // note: newrelic.service.name key will not required once service.name is guaranteed to be
   // provided via the Resource in the SDK.  See
   // https://github.com/newrelic/opentelemetry-exporter-java/issues/62
   // for the tracking issue.
-  static String getServiceName(ExporterConfig config) {
-    return config.getString(NEW_RELIC_SERVICE_NAME, DEFAULT_NEW_RELIC_SERVICE_NAME);
+  static String getServiceName(Properties config) {
+    return config.getProperty(NEW_RELIC_SERVICE_NAME, DEFAULT_NEW_RELIC_SERVICE_NAME);
   }
 
   String getServiceName() {
@@ -50,7 +50,7 @@ class NewRelicConfiguration {
   }
 
   String getMetricUri() {
-    return config.getString(NEW_RELIC_METRIC_URI_OVERRIDE, "");
+    return config.getProperty(NEW_RELIC_METRIC_URI_OVERRIDE, "");
   }
 
   boolean isTraceUriSpecified() {
@@ -58,8 +58,8 @@ class NewRelicConfiguration {
   }
 
   String getTraceUri() {
-    String deprecatedUriOverride = config.getString(NEW_RELIC_URI_OVERRIDE, "");
-    return config.getString(NEW_RELIC_TRACE_URI_OVERRIDE, deprecatedUriOverride);
+    String deprecatedUriOverride = config.getProperty(NEW_RELIC_URI_OVERRIDE, "");
+    return config.getProperty(NEW_RELIC_TRACE_URI_OVERRIDE, deprecatedUriOverride);
   }
 
   private boolean isSpecified(String s) {

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactory.java
@@ -11,10 +11,10 @@ import com.google.auto.service.AutoService;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter.Builder;
-import io.opentelemetry.javaagent.tooling.exporter.ExporterConfig;
-import io.opentelemetry.javaagent.tooling.exporter.MetricExporterFactory;
+import io.opentelemetry.javaagent.spi.exporter.MetricExporterFactory;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
 import java.net.URI;
+import java.util.Properties;
 
 /**
  * A {@link MetricExporterFactory} that creates a {@link MetricExporter} that sends metrics to New
@@ -30,7 +30,7 @@ public class NewRelicMetricExporterFactory implements MetricExporterFactory {
    * @return An implementation of a {@link MetricExporter}
    */
   @Override
-  public MetricExporter fromConfig(ExporterConfig config) {
+  public MetricExporter fromConfig(Properties config) {
     NewRelicConfiguration newRelicConfiguration = new NewRelicConfiguration(config);
 
     Builder builder =

--- a/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
+++ b/opentelemetry-exporters-newrelic-auto/src/main/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactory.java
@@ -10,10 +10,10 @@ import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.SERVICE
 import com.google.auto.service.AutoService;
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter;
-import io.opentelemetry.javaagent.tooling.exporter.ExporterConfig;
-import io.opentelemetry.javaagent.tooling.exporter.SpanExporterFactory;
+import io.opentelemetry.javaagent.spi.exporter.SpanExporterFactory;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
 import java.net.URI;
+import java.util.Properties;
 
 /**
  * A {@link SpanExporterFactory} that creates a {@link SpanExporter} that sends spans to New Relic.
@@ -28,7 +28,7 @@ public class NewRelicSpanExporterFactory implements SpanExporterFactory {
    * @return An implementation of a {@link SpanExporter}
    */
   @Override
-  public SpanExporter fromConfig(ExporterConfig config) {
+  public SpanExporter fromConfig(Properties config) {
     NewRelicConfiguration newRelicConfiguration = new NewRelicConfiguration(config);
     NewRelicSpanExporter.Builder newRelicSpanExporterBuilder =
         NewRelicSpanExporter.newBuilder()

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
@@ -12,8 +12,8 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.javaagent.tooling.exporter.ExporterConfig;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -22,7 +22,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class NewRelicMetricExporterFactoryTest {
 
-  @Mock private ExporterConfig config;
+  @Mock private Properties config;
 
   @Test
   void testFromConfig_HappyPath() {
@@ -31,10 +31,11 @@ class NewRelicMetricExporterFactoryTest {
     String serviceNameValue = "best service ever";
     String uriOverrideValue = "http://test.domain.com";
 
-    when(config.getString(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
-    when(config.getBoolean(NEW_RELIC_ENABLE_AUDIT_LOGGING, false)).thenReturn(true);
-    when(config.getString(NEW_RELIC_SERVICE_NAME, defaultServiceName)).thenReturn(serviceNameValue);
-    when(config.getString(NEW_RELIC_METRIC_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
+    when(config.getProperty(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
+    when(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false")).thenReturn("true");
+    when(config.getProperty(NEW_RELIC_SERVICE_NAME, defaultServiceName))
+        .thenReturn(serviceNameValue);
+    when(config.getProperty(NEW_RELIC_METRIC_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
 
     NewRelicMetricExporterFactory newRelicSpanExporterFactory = new NewRelicMetricExporterFactory();
     MetricExporter metricExporter = newRelicSpanExporterFactory.fromConfig(config);

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
@@ -13,8 +13,8 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.when;
 
-import io.opentelemetry.javaagent.tooling.exporter.ExporterConfig;
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -23,7 +23,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class NewRelicSpanExporterFactoryTest {
 
-  @Mock private ExporterConfig config;
+  @Mock private Properties config;
 
   @Test
   void testFromConfig_HappyPath() {
@@ -32,12 +32,13 @@ class NewRelicSpanExporterFactoryTest {
     String serviceNameValue = "best service ever";
     String uriOverrideValue = "http://test.domain.com";
 
-    when(config.getString(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
-    when(config.getBoolean(NEW_RELIC_ENABLE_AUDIT_LOGGING, false)).thenReturn(true);
-    when(config.getString(NEW_RELIC_SERVICE_NAME, defaultServiceName)).thenReturn(serviceNameValue);
-    when(config.getString(NEW_RELIC_TRACE_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
+    when(config.getProperty(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
+    when(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false")).thenReturn("true");
+    when(config.getProperty(NEW_RELIC_SERVICE_NAME, defaultServiceName))
+        .thenReturn(serviceNameValue);
+    when(config.getProperty(NEW_RELIC_TRACE_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
     // this is the legacy key which we should get rid of as soon as we can
-    when(config.getString(NEW_RELIC_URI_OVERRIDE, "")).thenReturn("");
+    when(config.getProperty(NEW_RELIC_URI_OVERRIDE, "")).thenReturn("");
 
     NewRelicSpanExporterFactory newRelicSpanExporterFactory = new NewRelicSpanExporterFactory();
     SpanExporter spanExporter = newRelicSpanExporterFactory.fromConfig(config);
@@ -52,12 +53,13 @@ class NewRelicSpanExporterFactoryTest {
     String serviceNameValue = "best service ever";
     String uriOverrideValue = "http://test.domain.com";
 
-    when(config.getString(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
-    when(config.getBoolean(NEW_RELIC_ENABLE_AUDIT_LOGGING, false)).thenReturn(true);
-    when(config.getString(NEW_RELIC_SERVICE_NAME, defaultServiceName)).thenReturn(serviceNameValue);
+    when(config.getProperty(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
+    when(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false")).thenReturn("true");
+    when(config.getProperty(NEW_RELIC_SERVICE_NAME, defaultServiceName))
+        .thenReturn(serviceNameValue);
     // this is the legacy key which we should get rid of as soon as we can
-    when(config.getString(NEW_RELIC_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
-    when(config.getString(NEW_RELIC_TRACE_URI_OVERRIDE, uriOverrideValue))
+    when(config.getProperty(NEW_RELIC_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
+    when(config.getProperty(NEW_RELIC_TRACE_URI_OVERRIDE, uriOverrideValue))
         .thenReturn(uriOverrideValue);
 
     NewRelicSpanExporterFactory newRelicSpanExporterFactory = new NewRelicSpanExporterFactory();


### PR DESCRIPTION
The interface moved packages, and this change is required to get the exporters working again.