### PR TITLE
Change mocked Properties object in tests to just be a simple Properties instance.

### DIFF
--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/AbstractExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/AbstractExporterFactoryTest.java
@@ -5,21 +5,21 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-import java.util.Properties;
-
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_API_KEY;
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_ENABLE_AUDIT_LOGGING;
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_SERVICE_NAME;
+
+import java.util.Properties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 abstract class AbstractExporterFactoryTest {
 
   protected Properties config;
   protected String defaultUriOverride = "http://test.domain.com";
+
   @BeforeEach
   void setup() {
     config = new Properties();

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/AbstractExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/AbstractExporterFactoryTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2020 New Relic Corporation. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package com.newrelic.telemetry.opentelemetry.export.auto;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Properties;
+
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_API_KEY;
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_ENABLE_AUDIT_LOGGING;
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_SERVICE_NAME;
+
+@ExtendWith(MockitoExtension.class)
+abstract class AbstractExporterFactoryTest {
+
+  protected Properties config;
+  protected String defaultUriOverride = "http://test.domain.com";
+  @BeforeEach
+  void setup() {
+    config = new Properties();
+    config.setProperty(NEW_RELIC_API_KEY, "test-key");
+    config.setProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "true");
+    config.setProperty(NEW_RELIC_SERVICE_NAME, "best service ever");
+  }
+}

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
@@ -5,11 +5,11 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import org.junit.jupiter.api.Test;
-
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_METRIC_URI_OVERRIDE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import org.junit.jupiter.api.Test;
 
 class NewRelicMetricExporterFactoryTest extends AbstractExporterFactoryTest {
 

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
@@ -9,13 +9,18 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-class NewRelicMetricExporterFactoryTest extends AbstractExporterFactoryTest {
+@ExtendWith(MockitoExtension.class)
+class NewRelicMetricExporterFactoryTest {
 
   @Test
   void testFromConfig_HappyPath() {
-    config.setProperty(NEW_RELIC_METRIC_URI_OVERRIDE, defaultUriOverride);
+    Properties config = TestProperties.newTestProperties();
+    config.setProperty(NEW_RELIC_METRIC_URI_OVERRIDE, TestProperties.defaultUriOverride);
     NewRelicMetricExporterFactory newRelicSpanExporterFactory = new NewRelicMetricExporterFactory();
     MetricExporter metricExporter = newRelicSpanExporterFactory.fromConfig(config);
 

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
@@ -5,38 +5,17 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_API_KEY;
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_ENABLE_AUDIT_LOGGING;
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_METRIC_URI_OVERRIDE;
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_SERVICE_NAME;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
-
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
-import java.util.Properties;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-class NewRelicMetricExporterFactoryTest {
+import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_METRIC_URI_OVERRIDE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-  @Mock private Properties config;
+class NewRelicMetricExporterFactoryTest extends AbstractExporterFactoryTest {
 
   @Test
   void testFromConfig_HappyPath() {
-    String apiKeyValue = "test-key";
-    String defaultServiceName = "(unknown service)";
-    String serviceNameValue = "best service ever";
-    String uriOverrideValue = "http://test.domain.com";
-
-    when(config.getProperty(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
-    when(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false")).thenReturn("true");
-    when(config.getProperty(NEW_RELIC_SERVICE_NAME, defaultServiceName))
-        .thenReturn(serviceNameValue);
-    when(config.getProperty(NEW_RELIC_METRIC_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
-
+    config.setProperty(NEW_RELIC_METRIC_URI_OVERRIDE, defaultUriOverride);
     NewRelicMetricExporterFactory newRelicSpanExporterFactory = new NewRelicMetricExporterFactory();
     MetricExporter metricExporter = newRelicSpanExporterFactory.fromConfig(config);
 

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
@@ -5,41 +5,18 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_API_KEY;
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_ENABLE_AUDIT_LOGGING;
-import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_SERVICE_NAME;
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.junit.jupiter.api.Test;
+
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_TRACE_URI_OVERRIDE;
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_URI_OVERRIDE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.Mockito.when;
 
-import io.opentelemetry.sdk.trace.export.SpanExporter;
-import java.util.Properties;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
-
-@ExtendWith(MockitoExtension.class)
-class NewRelicSpanExporterFactoryTest {
-
-  @Mock private Properties config;
+class NewRelicSpanExporterFactoryTest extends AbstractExporterFactoryTest {
 
   @Test
   void testFromConfig_HappyPath() {
-    String apiKeyValue = "test-key";
-    String defaultServiceName = "(unknown service)";
-    String serviceNameValue = "best service ever";
-    String uriOverrideValue = "http://test.domain.com";
-
-    when(config.getProperty(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
-    when(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false")).thenReturn("true");
-    when(config.getProperty(NEW_RELIC_SERVICE_NAME, defaultServiceName))
-        .thenReturn(serviceNameValue);
-    when(config.getProperty(NEW_RELIC_TRACE_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
-    // this is the legacy key which we should get rid of as soon as we can
-    when(config.getProperty(NEW_RELIC_URI_OVERRIDE, "")).thenReturn("");
-
+    config.setProperty(NEW_RELIC_TRACE_URI_OVERRIDE, "http://test.domain.com");
     NewRelicSpanExporterFactory newRelicSpanExporterFactory = new NewRelicSpanExporterFactory();
     SpanExporter spanExporter = newRelicSpanExporterFactory.fromConfig(config);
 
@@ -48,20 +25,8 @@ class NewRelicSpanExporterFactoryTest {
 
   @Test
   void testFromConfig_OldUriProperty() {
-    String apiKeyValue = "test-key";
-    String defaultServiceName = "(unknown service)";
-    String serviceNameValue = "best service ever";
-    String uriOverrideValue = "http://test.domain.com";
-
-    when(config.getProperty(NEW_RELIC_API_KEY, "")).thenReturn(apiKeyValue);
-    when(config.getProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "false")).thenReturn("true");
-    when(config.getProperty(NEW_RELIC_SERVICE_NAME, defaultServiceName))
-        .thenReturn(serviceNameValue);
-    // this is the legacy key which we should get rid of as soon as we can
-    when(config.getProperty(NEW_RELIC_URI_OVERRIDE, "")).thenReturn(uriOverrideValue);
-    when(config.getProperty(NEW_RELIC_TRACE_URI_OVERRIDE, uriOverrideValue))
-        .thenReturn(uriOverrideValue);
-
+    config.setProperty(NEW_RELIC_URI_OVERRIDE, "http://test.domain.com");
+    config.setProperty(NEW_RELIC_TRACE_URI_OVERRIDE, "http://test.domain.com");
     NewRelicSpanExporterFactory newRelicSpanExporterFactory = new NewRelicSpanExporterFactory();
     SpanExporter spanExporter = newRelicSpanExporterFactory.fromConfig(config);
 

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
@@ -5,12 +5,12 @@
 
 package com.newrelic.telemetry.opentelemetry.export.auto;
 
-import io.opentelemetry.sdk.trace.export.SpanExporter;
-import org.junit.jupiter.api.Test;
-
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_TRACE_URI_OVERRIDE;
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_URI_OVERRIDE;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import io.opentelemetry.sdk.trace.export.SpanExporter;
+import org.junit.jupiter.api.Test;
 
 class NewRelicSpanExporterFactoryTest extends AbstractExporterFactoryTest {
 

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicSpanExporterFactoryTest.java
@@ -10,12 +10,17 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.sdk.trace.export.SpanExporter;
+import java.util.Properties;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-class NewRelicSpanExporterFactoryTest extends AbstractExporterFactoryTest {
+@ExtendWith(MockitoExtension.class)
+class NewRelicSpanExporterFactoryTest {
 
   @Test
   void testFromConfig_HappyPath() {
+    Properties config = TestProperties.newTestProperties();
     config.setProperty(NEW_RELIC_TRACE_URI_OVERRIDE, "http://test.domain.com");
     NewRelicSpanExporterFactory newRelicSpanExporterFactory = new NewRelicSpanExporterFactory();
     SpanExporter spanExporter = newRelicSpanExporterFactory.fromConfig(config);
@@ -25,6 +30,7 @@ class NewRelicSpanExporterFactoryTest extends AbstractExporterFactoryTest {
 
   @Test
   void testFromConfig_OldUriProperty() {
+    Properties config = TestProperties.newTestProperties();
     config.setProperty(NEW_RELIC_URI_OVERRIDE, "http://test.domain.com");
     config.setProperty(NEW_RELIC_TRACE_URI_OVERRIDE, "http://test.domain.com");
     NewRelicSpanExporterFactory newRelicSpanExporterFactory = new NewRelicSpanExporterFactory();

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/TestProperties.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/TestProperties.java
@@ -10,21 +10,16 @@ import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfigura
 import static com.newrelic.telemetry.opentelemetry.export.auto.NewRelicConfiguration.NEW_RELIC_SERVICE_NAME;
 
 import java.util.Properties;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
-abstract class AbstractExporterFactoryTest {
+class TestProperties {
 
-  protected Properties config;
-  protected String defaultUriOverride = "http://test.domain.com";
+  protected static final String defaultUriOverride = "http://test.domain.com";
 
-  @BeforeEach
-  void setup() {
-    config = new Properties();
+  static Properties newTestProperties() {
+    Properties config = new Properties();
     config.setProperty(NEW_RELIC_API_KEY, "test-key");
     config.setProperty(NEW_RELIC_ENABLE_AUDIT_LOGGING, "true");
     config.setProperty(NEW_RELIC_SERVICE_NAME, "best service ever");
+    return config;
   }
 }


### PR DESCRIPTION
closes [https://github.com/newrelic/opentelemetry-exporter-java/issues/112](https://github.com/newrelic/opentelemetry-exporter-java/issues/112)