### PR TITLE
Update changelog and bump snapshot version to 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Coming soon
 - tbd
 
+## [0.10.0] - 2020-11-13
+- Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.10.0`
+- Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.10.1`
+
 ## [0.9.0] - 2020-10-29
-- Updates compatibility with `opentelemetry-java` 0.9.1
-- Updates compatibility with `opentelemetry-javaagent-spi` 0.9.0
+- Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.9.1`
+- Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.9.0`
 
 ## [0.8.1] - 2020-09-10
 - Fixes the inability to use the exporter with the auto-instrumentation agent version 0.8.0

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ To send spans or metrics to New Relic, you will need an [Insights Insert API Key
 Note: There is an example [BasicExample.java](opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java)  
 in the test source code hierarchy that matches this example code. It should be considered as the canonical code for this example, since OpenTelemetry internal SDK APIs are still a work in progress.
 
+### Configuration
+
+Currently, the New Relic OpenTelemetry exporter supports the following configuration via system properties. 
+
+| System property                                                                  | Purpose                                                                                                                                                                                                            |
+|----------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `newrelic.api.key`                                                               | **[Required]** The [Insights insert key](https://docs.newrelic.com/docs/telemetry-data-platform/ingest-manage-data/ingest-apis/use-event-api-report-custom-events#register) to report telemetry data to New Relic. |
+| `newrelic.service.name`                                                          | **[Recommended]** The service name of this JVM instance, default is `(unknown service)`.                                                                                                                           |
+| `newrelic.trace.uri.override`                                                    | The New Relic endpoint to connect to for reporting Spans, default is US Prod. For the EU region use: https://trace-api.eu.newrelic.com/trace/v1                                                                    |
+| `newrelic.metric.uri.override`                                                   | The New Relic endpoint to connect to for reporting metrics, default is US Prod. For the EU region use: https://metric-api.eu.newrelic.com/metric/v1                                                                |
+| `newrelic.enable.audit.logging`                                                  | Enable verbose audit logging to display the JSON batches sent each harvest.                                                                                                                                        |
+| `io.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug` | Enable `debug` logging for the exporter when running in the auto-instrumentation agent.                                                                                                                            |
+
 ## Installation
 
 If you need more flexibility, you can set up the individual exporters and the SDK by hand:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ repositories {
 ```
 
 ```
-implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.9.0")
+implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.10.0")
 implementation("io.opentelemetry:opentelemetry-sdk:0.10.0")
 implementation("com.newrelic.telemetry:telemetry-core:0.9.0")
 implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.9.0")

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ repositories {
 
 ```
 implementation("com.newrelic.telemetry:opentelemetry-exporters-newrelic:0.9.0")
-implementation("io.opentelemetry:opentelemetry-sdk:0.9.1")
+implementation("io.opentelemetry:opentelemetry-sdk:0.10.0")
 implementation("com.newrelic.telemetry:telemetry-core:0.9.0")
 implementation("com.newrelic.telemetry:telemetry-http-okhttp:0.9.0")
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 # Passing in -Prelease=true will render a non-snapshot version.
 # All other values (including unset) will render a snapshot version.
 
-baseVersion = 0.10.0
+baseVersion = 0.11.0
 
 # set this to true to enable using a local sonatype (for debugging publishing issues)
 # (start a local sonatype in docker with this command: $ docker run -d -p 8081:8081 --name nexus sonatype/nexus3)


### PR DESCRIPTION
Housekeeping after publishing 0.10.0 release.
https://github.com/newrelic/opentelemetry-exporter-java/releases/tag/v0.10.0