### PR TITLE
fix artifact publishing with gradle 6.7.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ listOf(":opentelemetry-exporters-newrelic", ":opentelemetry-exporters-newrelic-a
         configure<PublishingExtension> {
             publications {
                 create<MavenPublication>("mavenJava") {
-                    from(components["java"])
+                    artifact(file("$buildDir/libs/${project.name}-${project.version}.jar"))
                     artifact(tasks["sourcesJar"])
                     artifact(tasks["javadocJar"])
                     pom {

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -31,6 +31,13 @@ tasks {
     build {
         dependsOn("generateVersionResource")
     }
+
+    publishMavenJavaPublicationToMavenLocal {
+        dependsOn(jar)
+    }
+    publishMavenJavaPublicationToMavenRepository {
+        dependsOn(jar)
+    }
 }
 
 


### PR DESCRIPTION
When I updated to gradle wrapper 6.7.1, I broke artifact publishing because gradle added additional safety checks which the project's publishing was relying on not being present. The additional safety checks are described briefly here: https://docs.gradle.org/current/userguide/upgrading_version_6.html#publishing_spring_boot_applications

We're not a spring boot app, but were suffering from a similar problem due to our use of the shadow jar plugin in the `opentelemetry-exporters-newrelic-auto` module. I've fixed the problem by explicitly declaring the artifacts that should be published, and take advantage of the fact that `:opentelemetry-exporters-newrelic:jar` and `:opentelemetry-exporters-newrelic-auto:shadowJar` produce artifacts with the same pattern despite being two different task types.