### PR TITLE
Support otel sdk 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Coming soon
-- tbd
+[0.11.0] - 2020-12-nn
+- Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.11.0`
+- Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.11.0`
 
 ## [0.10.0] - 2020-11-13
 - Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.10.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Coming soon
-[0.11.0] - 2020-12-nn
+- tbd
+
+## [0.11.0] - 2020-12-10
 - Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.11.0`
 - Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.11.0`
 

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ progress.
 The easiest way to get started using the OpenTelemetry SDK with the New Relic exporters is as follows:
 
 Add required dependencies in `build.gradle` (see [Published Artifacts](#Published-Artifacts) for versions):
+
 ```
 repositories {
     maven {
@@ -49,60 +50,80 @@ dependencies {
 }
 ```
 
-Call the APIs in the application:
+Use the provided APIs in your application to set up exporters to record and send OpenTelemetry trace and metric data:
+
 ```java
-    // Create a configuration object
+    // Configure the New Relic exporters.
     NewRelicExporters.Configuration configuration =
-      new NewRelicExporters.Configuration(apiKey, "My Service Name")
-        .enableAuditLogging()           // Optionally enable audit logging
-        .collectionIntervalSeconds(10); // Set the reporting interval for metrics and spans to 10 seconds
-    
-    // Call start with the configuration
+        new NewRelicExporters.Configuration(apiKey, "My Service Name")
+            .enableAuditLogging() // Optionally enable audit logging
+            .collectionIntervalSeconds(
+                10); // Set the reporting interval for metrics/spans to 10 seconds
+
+    // Start the exporters with the supplied configuration. This starts both a NewRelicSpanExporter
+    // and a NewRelicMetricExporter as well as a BatchSpanProcessor and an IntervalMetricReader, the
+    // latter of which manage the batching and sending of their respective telemetry data types.
     NewRelicExporters.start(configuration);
-    
-    // Call the OpenTelemetry SDK to obtain tracers and meters to record data
+
+    // Now that we've got the SDK configured and the exporters started, let's write some very simple
+    // instrumentation to demonstrate how it all works.
+
+    // Call the OpenTelemetry SDK to obtain tracers and meters to record data.
+    // A Tracer is used to create Spans that form traces.
     Tracer tracer = OpenTelemetry.getGlobalTracerProvider().get("sample-app", "1.0");
+    // A Meter is used to create different instruments to record metrics.
     Meter meter = OpenTelemetry.getGlobalMeterProvider().get("sample-app", "1.0");
 
-    // ... when the application is complete, be sure call shutdown to stop the exporters
+    // Use the tracer and meter to record telemetry data for your application. See the sections 
+    // in the README on Recording Spans and Recording Metrics for specific usage examples. 
+
+    // When the application is complete, be sure to call shutdown to stop the exporters.
+    // This will flush any data from the exporters before they exit.
     NewRelicExporters.shutdown();
 ```
 
-The previous code hides some boilerplate code that can be further customized if more flexibility is required. [Recording Spans](#Recording-Spans) and 
-[Recording Metrics](#Recording-Metrics) describe this and how to use the APIs to record data in more detail.
+The previous example hides some boilerplate code that can be further customized if more flexibility is required. Specifically the call to 
+`NewRelicExporters.start(configuration)` automatically starts both a `NewRelicSpanExporter` and a `NewRelicMetricExporter` for you using the same configuration 
+for both. If you wish to configure each exporter separately, or simply don't need to export both spans and metrics, then [Recording Spans](#Recording-Spans) 
+and [Recording Metrics](#Recording-Metrics) sections describe how to do this as well as how to use the Tracer and Meter APIs to record telemetry data.
 
 #### Recording Spans
  
 [BasicExample.java](opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java) demonstrates the easiest way
-to configure the span exporter. If your application needs more flexibility, it can be further configured as follows:
+to configure the span exporter. If your application needs more flexibility, it can be further configured as follows (see the `NewRelicSpanExporter` 
+and `BatchSpanProcessor` APIs for all configuration options):
 
 ```java
-    // Create a NewRelicSpanExporter
-    NewRelicSpanExporter exporter = NewRelicSpanExporter.newBuilder()
-        .apiKey(System.getenv("INSIGHTS_INSERT_KEY"))
-        .commonAttributes(new Attributes().put(SERVICE_NAME, "best service ever"))
-        .build();
-    
-    // Use the NewRelicSpanExporter to build a OpenTelemetry BatchSpansProcessor
-    BatchSpanProcessor spanProcessor = BatchSpanProcessor.newBuilder(exporter)
-        .setScheduleDelayMillis(10_000) // Optionally override the default schedule delay
-        .build();
+    // Explicitly create and configure a NewRelicSpanExporter.
+    NewRelicSpanExporter exporter =
+        NewRelicSpanExporter.newBuilder()
+            .apiKey(System.getenv("INSIGHTS_INSERT_KEY"))
+            .commonAttributes(new Attributes().put(SERVICE_NAME, "best service ever"))
+            .build();
 
-    // Register the span processor with the default TracerSdkManagement of the OpenTelemetrySdk
-   OpenTelemetrySdk.getTracerManagement().tracerManagement.addSpanProcessor(spanProcessor);
+    // Use the NewRelicSpanExporter to create and configure a BatchSpansProcessor.
+    BatchSpanProcessor spanProcessor =
+        BatchSpanProcessor.builder(exporter)
+            .setScheduleDelayMillis(10_000) // Optionally override the default schedule delay
+            .build();
+
+    // Register the span processor with the default TracerSdkManagement of the OpenTelemetrySdk.
+    OpenTelemetrySdk.getGlobalTracerManagement().addSpanProcessor(spanProcessor);
 ```
 
 Once the span exporter has been registered with the `OpenTelemetrySdk`, spans can be recorded as follows:
 
 ```java
-    // Create an OpenTelemetry Tracer and use it to record spans
-    Tracer tracer = OpenTelemetry.getTracerProvider().get("sample-app", "1.0");
-    
-    Span span = tracer.spanBuilder("testSpan").setSpanKind(Kind.INTERNAL).startSpan();
-    try (Scope scope = tracer.withSpan(span)) {
-      //do some work
-      Thread.sleep(1000);
-      span.end();
+    // Create an OpenTelemetry Tracer and use it to record spans.
+    Tracer tracer = OpenTelemetry.getGlobalTracerProvider().get("sample-app", "1.0");
+
+    Span span = tracer.spanBuilder("testSpan").setSpanKind(Span.Kind.INTERNAL).startSpan();
+    try (Scope scope = span.makeCurrent()) {
+        // do some work
+    } catch (Throwable t) {
+        span.setStatus(StatusCode.ERROR, "error description"); // record error details.
+    } finally {
+        span.end(); // closing the scope does not end the span, this has to be done manually.
     }
 ```
 
@@ -111,21 +132,22 @@ Find your spans in New Relic One: go to [New Relic One](https://one.newrelic.com
 #### Recording Metrics
 
 [BasicExample.java](opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java) demonstrates the easiest way
-to configure the metric exporter. If your application needs more flexibility, it can be further configured as follows:
+to configure the metric exporter. If your application needs more flexibility, it can be further configured as follows (see the `NewRelicMetricExporter` 
+and `IntervalMetricReader` APIs for all configuration options):
 
 ```java
-    // Create a NewRelicMetricExporter
+    // Explicitly create and configure a NewRelicMetricExporter.
     MetricExporter metricExporter =
         NewRelicMetricExporter.newBuilder()
           .apiKey(System.getenv("INSIGHTS_INSERT_KEY"))
           .commonAttributes(new Attributes().put(SERVICE_NAME, "best service ever"))
           .build();
 
-    // Create an IntervalMetricReader configured to batch up metrics every 5 seconds
+    // Use the NewRelicMetricExporter to create and configure an IntervalMetricReader.
     IntervalMetricReader intervalMetricReader =
         IntervalMetricReader.builder()
             .setMetricProducers(
-                Collections.singleton(OpenTelemetrySdk.getMeterProvider().getMetricProducer()))
+                Collections.singleton(OpenTelemetrySdk.getGlobalMeterProvider().getMetricProducer()))
             .setExportIntervalMillis(5000) // Batch up metrics every 5 seconds, or on whatever schedule the application requires
             .setMetricExporter(metricExporter)
             .build();
@@ -134,31 +156,40 @@ to configure the metric exporter. If your application needs more flexibility, it
 Once the `IntervalMetricReader` has been setup with the metric exporter, metrics can be recorded as follows:
 
 ```java
-    // Recording metrics starts with obtaining a meter. The meter can then be used to obtain instruments
-    // to which the application reports measurements.
-    Meter meter = OpenTelemetry.getMeterProvider().get("sample-app", "1.0");
+    // A Meter is used to create different instruments to record metrics.
+    Meter meter = OpenTelemetry.getGlobalMeterProvider().get("sample-app", "1.0");
 
-    // Obtain a counter from the meter
+    // Use the meter to create a LongCounter instrument to record metrics.
     LongCounter spanCounter =
         meter
             .longCounterBuilder("spanCounter")
             .setUnit("one")
             .setDescription("Counting all the spans")
-            .setMonotonic(true)
             .build();
 
-    // Obtain a measure from the meter
-    LongMeasure spanTimer =
+    // Use the meter to create a LongValueRecorder instrument to record metrics.
+    LongValueRecorder spanTimer =
         meter
-            .longMeasureBuilder("spanTimer")
+            .longValueRecorderBuilder("spanTimer")
             .setUnit("ms")
             .setDescription("How long the spans take")
-            .setAbsolute(true)
             .build();
     
-    // Use the instruments to record measurements
-   spanCounter.add(1, "spanName", "testSpan", "isItAnError", "true");
-   spanTimer.record(1000, "spanName", "testSpan"); 
+    // Use the meter to create a LongUpDownCounter instrument to record metrics.
+    LongUpDownCounter upDownCounter =
+        meter
+            .longUpDownCounterBuilder("jim")
+            .setDescription("some good testing")
+            .setUnit("1")
+            .build();
+
+    // Use the instruments to record metric measurements.
+    spanCounter.add(1, Labels.of("spanName", "testSpan", "isItAnError", "" + markAsError));
+    upDownCounter.add(random.nextInt(100) - 50);
+
+    // Optionally, you can pre-bind a set of labels, rather than passing them in every time.
+    LongValueRecorder.BoundLongValueRecorder boundTimer = spanTimer.bind(Labels.of("spanName", "testSpan"));
+    boundTimer.record(System.currentTimeMillis() - startTime);
 ```
 
 To find your metrics in New Relic One, go to [New Relic One](https://one.newrelic.com/) and locate your service in the **Entity explorer** 
@@ -244,6 +275,8 @@ For general querying information, see:
 - [Intro to NRQL](https://docs.newrelic.com/docs/query-data/nrql-new-relic-query-language/getting-started/introduction-nrql)
 
 ## Building
+
+Requires Java 9+ to build.
 
 CI builds are run on Github Actions:
 

--- a/README.md
+++ b/README.md
@@ -276,7 +276,7 @@ For general querying information, see:
 
 ## Building
 
-Requires Java 9+ to build.
+Requires Java 8+ to build.
 
 CI builds are run on Github Actions:
 

--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -15,8 +15,8 @@ dependencies {
     annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
     api("com.google.auto.service:auto-service-annotations:1.0-rc7")
     api(project(":opentelemetry-exporters-newrelic"))
-    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.10.1")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.10.0")
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.11.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.11.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")

--- a/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
+++ b/opentelemetry-exporters-newrelic-auto/src/test/java/com/newrelic/telemetry/opentelemetry/export/auto/NewRelicMetricExporterFactoryTest.java
@@ -10,8 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
+import java.util.Collections;
 import java.util.Properties;
-import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -32,6 +32,6 @@ class NewRelicMetricExporterFactoryTest {
   @Test
   void testGetNames() {
     NewRelicMetricExporterFactory factory = new NewRelicMetricExporterFactory();
-    assertEquals(Set.of("newrelic"), factory.getNames());
+    assertEquals(Collections.singleton("newrelic"), factory.getNames());
   }
 }

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")
     implementation("org.slf4j:slf4j-api:1.7.26")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:$newRelicTelemetrySdkVersion")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.10.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.11.0")
 
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/examples/BasicExample.java
@@ -6,7 +6,6 @@
 package com.newrelic.telemetry.opentelemetry.examples;
 
 import com.newrelic.telemetry.opentelemetry.export.NewRelicExporters;
-import com.newrelic.telemetry.opentelemetry.export.NewRelicExporters.Configuration;
 import io.opentelemetry.api.OpenTelemetry;
 import io.opentelemetry.api.common.Labels;
 import io.opentelemetry.api.metrics.LongCounter;
@@ -19,27 +18,38 @@ import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Scope;
 import java.util.Random;
 
+/**
+ * An example illustrating common usage of the New Relic OpenTelemetry exporter. This example walks
+ * through using OpenTracing APIs/SDKs to manually instrument application code and setting up the
+ * New Relic OpenTelemetry exporter for reporting OpenTelemetry trace and metric data to New Relic.
+ */
 public class BasicExample {
 
-  public static void main(String[] args) throws InterruptedException {
+  public static void main(String[] args) {
     String apiKey = System.getenv("INSIGHTS_INSERT_KEY");
 
-    // 1. The simplest way to configure the New Relic exporters is like this:
-    Configuration configuration =
-        new Configuration(apiKey, "best service ever")
-            .enableAuditLogging()
-            .collectionIntervalSeconds(10);
+    // Configure the New Relic exporters.
+    NewRelicExporters.Configuration configuration =
+        new NewRelicExporters.Configuration(apiKey, "My Service Name")
+            .enableAuditLogging() // Optionally enable audit logging.
+            .collectionIntervalSeconds(
+                10); // Set the reporting interval for metrics/spans to 10 seconds.
+
+    // Start the exporters with the supplied configuration. This starts both a NewRelicSpanExporter
+    // and a NewRelicMetricExporter as well as a BatchSpanProcessor and an IntervalMetricReader, the
+    // latter of which manage the batching and sending of their respective telemetry data types.
     NewRelicExporters.start(configuration);
 
-    // Now, we've got the SDK configured and the exporters started.
-    // Let's write some very simple instrumentation to demonstrate how it all works.
+    // Now that we've got the SDK configured and the exporters started, let's write some very simple
+    // instrumentation to demonstrate how it all works.
 
-    // 2. Create an OpenTelemetry `Tracer` and a `Meter` and use them for some manual
-    // instrumentation.
+    // Call the OpenTelemetry SDK to obtain tracers and meters to record data.
+    // A Tracer is used to create Spans that form traces.
     Tracer tracer = OpenTelemetry.getGlobalTracerProvider().get("sample-app", "1.0");
+    // A Meter is used to create different instruments to record metrics.
     Meter meter = OpenTelemetry.getGlobalMeterProvider().get("sample-app", "1.0");
 
-    // 3. Here is an example of a counter
+    // Use the meter to create a LongCounter instrument to record metrics.
     LongCounter spanCounter =
         meter
             .longCounterBuilder("spanCounter")
@@ -47,7 +57,7 @@ public class BasicExample {
             .setDescription("Counting all the spans")
             .build();
 
-    // 4. Here's an example of a measure.
+    // Use the meter to create a LongValueRecorder instrument to record metrics.
     LongValueRecorder spanTimer =
         meter
             .longValueRecorderBuilder("spanTimer")
@@ -55,22 +65,23 @@ public class BasicExample {
             .setDescription("How long the spans take")
             .build();
 
+    // Use the meter to create a LongUpDownCounter instrument to record metrics.
     LongUpDownCounter upDownCounter =
         meter
-            .longUpDownCounterBuilder("jim")
-            .setDescription("some good testing")
+            .longUpDownCounterBuilder("upDownCounter")
+            .setDescription("Counter that can sum negative values")
             .setUnit("1")
             .build();
 
-    // 5. Optionally, you can pre-bind a set of labels, rather than passing them in every time.
+    // Optionally, you can pre-bind a set of labels, rather than passing them in every time.
     LongValueRecorder.BoundLongValueRecorder boundTimer =
         spanTimer.bind(Labels.of("spanName", "testSpan"));
 
-    // 6. use these to instrument some work
+    // Use the instruments to record metric measurements and the tracer for spans.
     doSomeSimulatedWork(tracer, spanCounter, upDownCounter, boundTimer);
 
-    // clean up so the JVM can exit. Note: these will flush any data to the exporter
-    // before they exit.
+    // When the application is complete, be sure to call shutdown to stop the exporters.
+    // This will flush any data from the exporters before they exit.
     NewRelicExporters.shutdown();
   }
 
@@ -78,24 +89,36 @@ public class BasicExample {
       Tracer tracer,
       LongCounter spanCounter,
       LongUpDownCounter upDownCounter,
-      LongValueRecorder.BoundLongValueRecorder boundTimer)
-      throws InterruptedException {
+      LongValueRecorder.BoundLongValueRecorder boundTimer) {
     Random random = new Random();
+
     for (int i = 0; i < 10; i++) {
       long startTime = System.currentTimeMillis();
       Span span =
           tracer.spanBuilder("testSpan").setSpanKind(Span.Kind.INTERNAL).setNoParent().startSpan();
-      try (Scope ignored = span.makeCurrent()) {
+
+      // Start timing for the span
+      try (Scope scope = span.makeCurrent()) {
         boolean markAsError = random.nextBoolean();
+
         if (markAsError) {
           span.setStatus(StatusCode.ERROR, "internalError");
         }
+
+        // Use the instruments to record measurements
         spanCounter.add(1, Labels.of("spanName", "testSpan", "isItAnError", "" + markAsError));
         upDownCounter.add(random.nextInt(100) - 50);
-        // do some work
+
+        // Do some busy waiting work
         Thread.sleep(random.nextInt(1000));
-        span.end();
+
+        // Use the boundTimer instrument to record another measurement
         boundTimer.record(System.currentTimeMillis() - startTime);
+      } catch (Throwable t) {
+        span.setStatus(StatusCode.ERROR, "error description"); // record error details
+      } finally {
+        // End timing for the span
+        span.end(); // closing the scope does not end the span, this has to be done manually
       }
     }
   }


### PR DESCRIPTION
Addresses https://github.com/newrelic/opentelemetry-exporter-java/issues/132

Ran with otel Java agent 0.11.0:

```
-javaagent:/path/to/spring-petclinic/opentelemetry/opentelemetry-javaagent-all.jar
-Dotel.exporter.jar=/path/to/opentelemetry-exporter-java/opentelemetry-exporters-newrelic-auto/build/libs/opentelemetry-exporters-newrelic-auto-0.11.0-SNAPSHOT.jar
-Dnewrelic.api.key=<KEY>
-Dnewrelic.service.name=otel-distro-test
-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug
-Dnewrelic.enable.audit.logging=true
```

```
[opentelemetry.auto.trace 2020-12-09 22:25:08:285 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://trace-api.newrelic.com/trace/v1
[opentelemetry.auto.trace 2020-12-09 22:25:08:286 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-09 22:25:08:305 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed span exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter
[opentelemetry.auto.trace 2020-12-09 22:25:08:316 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://metric-api.newrelic.com/metric/v1
[opentelemetry.auto.trace 2020-12-09 22:25:08:316 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-09 22:25:08:320 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed metric exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter
[opentelemetry.auto.trace 2020-12-09 22:25:08:329 -0800] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 0.11.0

[opentelemetry.auto.trace 2020-12-09 22:25:13:349 -0800] [Thread-6] DEBUG com.newrelic.telemetry.spans.SpanBatchSender - Sending a span batch (number of spans: 72) to the New Relic span ingest endpoint)
[opentelemetry.auto.trace 2020-12-09 22:25:13:349 -0800] [Thread-6] DEBUG com.newrelic.telemetry.spans.json.SpanBatchMarshaller - Generating json for span batch.
[opentelemetry.auto.trace 2020-12-09 22:25:13:363 -0800] [Thread-6] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json: [{"common":{"attributes":{"telemetry.sdk.language":"java","service.name":"otel-distro-test","service.instance.id":"eb4a085d-7cc3-48b3-ac43-5b6430b8c8ec","telemetry.sdk.version":"0.11.0","telemetry.auto.version":"0.11.0","collector.name":"newrelic-opentelemetry-exporter","instrumentation.provider":"opentelemetry","telemetry.sdk.name":"opentelemetry"}},"spans":[{"id":"2b23133e6e62a661","trace.id":"7ce441c57e1f922ac41e727e0319627d","timestamp":1607581513053,"attributes":{"duration.ms":6.026331,"db
...
[opentelemetry.auto.trace 2020-12-09 22:25:14:076 -0800] [Thread-6] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API: code: 202, body: {"requestId":"f31744fe-0001-b000-0000-01764b533932"}
[opentelemetry.auto.trace 2020-12-09 22:25:14:078 -0800] [Thread-6] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry batch sent
```

Here's a trace that combines both auto-instrumentation and [manual instrumentation](https://github.com/jasonjkeller/spring-petclinic/blob/opentelemetry-auto-instrumentation/src/main/java/org/springframework/samples/petclinic/system/WelcomeController.java#L40-L56) in a Spring controller: https://one.nr/0DvwB1qy2Qp

<img width="1270" alt="Screen Shot 2020-12-10 at 8 43 11 AM" src="https://user-images.githubusercontent.com/3496648/101801992-cc90af80-3ac3-11eb-9661-c7b0490be4ad.png">
