### PR TITLE
Add support for OTel 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Coming soon
+- tbd
+
+## [0.12.0] - 2020-12-14
 - Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.12.0`
 - Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.12.1`
 

--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -15,8 +15,8 @@ dependencies {
     annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
     api("com.google.auto.service:auto-service-annotations:1.0-rc7")
     api(project(":opentelemetry-exporters-newrelic"))
-    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.11.0")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.11.0")
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.12.1")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.12.0")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")
     implementation("org.slf4j:slf4j-api:1.7.26")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:$newRelicTelemetrySdkVersion")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.11.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.12.0")
 
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupport.java
@@ -9,9 +9,6 @@ import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUM
 import static com.newrelic.telemetry.opentelemetry.export.AttributeNames.INSTRUMENTATION_VERSION;
 
 import com.newrelic.telemetry.Attributes;
-import io.opentelemetry.api.common.AttributeConsumer;
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.UUID;
@@ -37,29 +34,27 @@ public class AttributesSupport {
 
   static Attributes addResourceAttributes(Attributes attributes, Resource resource) {
     if (resource != null) {
-      ReadableAttributes labelsMap = resource.getAttributes();
+      io.opentelemetry.api.common.Attributes labelsMap = resource.getAttributes();
       putInAttributes(attributes, labelsMap);
     }
     return attributes;
   }
 
-  static void putInAttributes(Attributes attributes, ReadableAttributes originalAttributes) {
+  static void putInAttributes(
+      Attributes attributes, io.opentelemetry.api.common.Attributes originalAttributes) {
     originalAttributes.forEach(
-        new AttributeConsumer() {
-          @Override
-          public <T> void accept(AttributeKey<T> key, T value) {
-            switch (key.getType()) {
-              case STRING:
-                attributes.put(key.getKey(), (String) value);
-                break;
-              case BOOLEAN:
-                attributes.put(key.getKey(), (Boolean) value);
-                break;
-              case LONG:
-              case DOUBLE:
-                attributes.put(key.getKey(), (Number) value);
-                break;
-            }
+        (key, value) -> {
+          switch (key.getType()) {
+            case STRING:
+              attributes.put(key.getKey(), (String) value);
+              break;
+            case BOOLEAN:
+              attributes.put(key.getKey(), (Boolean) value);
+              break;
+            case LONG:
+            case DOUBLE:
+              attributes.put(key.getKey(), (Number) value);
+              break;
           }
         });
   }

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -20,7 +20,7 @@ import com.newrelic.telemetry.metrics.Metric;
 import com.newrelic.telemetry.metrics.MetricBatchSender;
 import com.newrelic.telemetry.metrics.MetricBuffer;
 import io.opentelemetry.sdk.common.CompletableResultCode;
-import io.opentelemetry.sdk.internal.MillisClock;
+import io.opentelemetry.sdk.internal.SystemClock;
 import io.opentelemetry.sdk.metrics.data.MetricData;
 import io.opentelemetry.sdk.metrics.data.MetricData.Point;
 import io.opentelemetry.sdk.metrics.export.MetricExporter;
@@ -207,7 +207,7 @@ public class NewRelicMetricExporter implements MetricExporter {
      * @return a new {@link NewRelicMetricExporter} instance
      */
     public NewRelicMetricExporter build() {
-      TimeTracker timeTracker = new TimeTracker(MillisClock.getInstance());
+      TimeTracker timeTracker = new TimeTracker(SystemClock.getInstance());
       if (telemetryClient != null) {
         return new NewRelicMetricExporter(
             telemetryClient,

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapter.java
@@ -20,7 +20,6 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.Span;
 import com.newrelic.telemetry.spans.Span.SpanBuilder;
 import com.newrelic.telemetry.spans.SpanBatch;
-import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.sdk.resources.Resource;
 import io.opentelemetry.sdk.trace.data.SpanData;
@@ -101,7 +100,7 @@ class SpanBatchAdapter {
   }
 
   private static Attributes createIntrinsicAttributes(SpanData span, Attributes attributes) {
-    ReadableAttributes originalAttributes = span.getAttributes();
+    io.opentelemetry.api.common.Attributes originalAttributes = span.getAttributes();
     putInAttributes(attributes, originalAttributes);
     attributes.put(SPAN_KIND, span.getKind().name());
     return attributes;
@@ -117,7 +116,7 @@ class SpanBatchAdapter {
 
   private static String getErrorMessage(SpanData.Status status) {
     String description = status.getDescription();
-    return isNullOrEmpty(description) ? status.getCanonicalCode().name() : description;
+    return isNullOrEmpty(description) ? status.getStatusCode().name() : description;
   }
 
   private static boolean isNullOrEmpty(String string) {

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupportTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/AttributesSupportTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import com.newrelic.telemetry.Attributes;
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
 import java.util.Arrays;
@@ -61,7 +60,7 @@ class AttributesSupportTest {
   @Test
   void addResourceAttributes_happyPath() {
     Attributes attributes = new Attributes().put("a", "b");
-    ReadableAttributes resourceAttributes =
+    io.opentelemetry.api.common.Attributes resourceAttributes =
         io.opentelemetry.api.common.Attributes.of(
             AttributeKey.stringKey("r1"),
             "v1",
@@ -80,7 +79,7 @@ class AttributesSupportTest {
   @Test
   void addResourceAttributes_resourceWinsVsInput() {
     Attributes attributes = new Attributes().put("r1", "v77");
-    ReadableAttributes resourceAttributes =
+    io.opentelemetry.api.common.Attributes resourceAttributes =
         io.opentelemetry.api.common.Attributes.of(
             AttributeKey.stringKey("r1"),
             "v1",
@@ -98,7 +97,7 @@ class AttributesSupportTest {
   @Test
   void putInAttributes_allTypes() {
     Attributes attrs = new Attributes().put("y", "z");
-    ReadableAttributes original =
+    io.opentelemetry.api.common.Attributes original =
         io.opentelemetry.api.common.Attributes.of(
             AttributeKey.stringKey("r1"),
             "v1",

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/SpanBatchAdapterTest.java
@@ -21,6 +21,7 @@ import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.spans.SpanBatch;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.common.InstrumentationLibraryInfo;
 import io.opentelemetry.sdk.resources.Resource;
@@ -37,6 +38,7 @@ class SpanBatchAdapterTest {
   private final String spanId = "000000000012d685";
   private final String traceId = "000000000063d76f0000000037fe0393";
   private final String parentSpanId = "000000002e5a40d9";
+  private final SpanContext noOpParentSpanContext = SpanContext.getInvalid();
 
   @Test
   void testSendBatchWithSingleSpan() {
@@ -81,6 +83,7 @@ class SpanBatchAdapterTest {
             .setSpanId(spanId)
             .setStartEpochNanos(1_000_456_001_000L)
             .setParentSpanId(parentSpanId)
+            .setParentSpanContext(noOpParentSpanContext)
             .setEndEpochNanos(1_001_789_021_111L)
             .setName("spanName")
             .setStatus(SpanData.Status.ok())
@@ -119,6 +122,7 @@ class SpanBatchAdapterTest {
             .setSpanId(spanId)
             .setStartEpochNanos(1_000_456_001_000L)
             .setParentSpanId(parentSpanId)
+            .setParentSpanContext(noOpParentSpanContext)
             .setEndEpochNanos(1_001_789_021_111L)
             .setName("spanName")
             .setStatus(SpanData.Status.ok())
@@ -134,6 +138,7 @@ class SpanBatchAdapterTest {
             .setSpanId(spanId)
             .setStartEpochNanos(1_000_456_001_000L)
             .setParentSpanId(parentSpanId)
+            .setParentSpanContext(noOpParentSpanContext)
             .setEndEpochNanos(1_001_789_021_111L)
             .setName("spanName")
             .setStatus(SpanData.Status.ok())

--- a/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/TestSpanData.java
+++ b/opentelemetry-exporters-newrelic/src/test/java/com/newrelic/telemetry/opentelemetry/export/TestSpanData.java
@@ -6,8 +6,8 @@
 package com.newrelic.telemetry.opentelemetry.export;
 
 import io.opentelemetry.api.common.Attributes;
-import io.opentelemetry.api.common.ReadableAttributes;
 import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanId;
 import io.opentelemetry.api.trace.TraceFlags;
 import io.opentelemetry.api.trace.TraceState;
@@ -23,6 +23,7 @@ public class TestSpanData implements SpanData {
   private final long startEpochNanos;
   private final long endEpochNanos;
   private final String parentSpanId;
+  private final SpanContext parentSpanContext;
   private final String spanName;
   private final Span.Kind kind;
   private final Status status;
@@ -38,6 +39,7 @@ public class TestSpanData implements SpanData {
     this.startEpochNanos = builder.startEpochNanos;
     this.endEpochNanos = builder.endEpochNanos;
     this.parentSpanId = builder.parentSpanId;
+    this.parentSpanContext = builder.parentSpanContext;
     this.spanName = builder.spanName;
     this.kind = builder.kind;
     this.status = builder.status;
@@ -72,6 +74,11 @@ public class TestSpanData implements SpanData {
   }
 
   @Override
+  public SpanContext getParentSpanContext() {
+    return parentSpanContext;
+  }
+
+  @Override
   public String getParentSpanId() {
     return parentSpanId;
   }
@@ -102,7 +109,7 @@ public class TestSpanData implements SpanData {
   }
 
   @Override
-  public ReadableAttributes getAttributes() {
+  public io.opentelemetry.api.common.Attributes getAttributes() {
     return attributes;
   }
 
@@ -157,6 +164,8 @@ public class TestSpanData implements SpanData {
     private String spanId;
     private long startEpochNanos;
     private String parentSpanId = SpanId.getInvalid();
+    private SpanContext parentSpanContext;
+
     private long endEpochNanos;
     private String spanName;
     private Status status;
@@ -183,6 +192,11 @@ public class TestSpanData implements SpanData {
 
     public Builder setParentSpanId(String parentSpanId) {
       this.parentSpanId = parentSpanId;
+      return this;
+    }
+
+    public Builder setParentSpanContext(SpanContext parentSpanContext) {
+      this.parentSpanContext = parentSpanContext;
       return this;
     }
 


### PR DESCRIPTION
This adds support to the exporter for OpenTelemetry SDK v0.12.0. There were a few breaking changes to the SDK that had to be addressed in the exporter: https://github.com/open-telemetry/opentelemetry-java/releases/tag/v0.12.0

```
-javaagent:/Users/jkeller/code/spring-petclinic/opentelemetry/opentelemetry-javaagent-0.12.1-all.jar
-Dotel.exporter.jar=/Users/jkeller/code/opentelemetry-exporter-java/opentelemetry-exporters-newrelic-auto/build/libs/opentelemetry-exporters-newrelic-auto-0.12.0-SNAPSHOT.jar
-Dnewrelic.api.key=KEY
-Dnewrelic.service.name=otel-distro-test
-Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug
-Dnewrelic.enable.audit.logging=true
```


<img width="1300" alt="trace" src="https://user-images.githubusercontent.com/3496648/101969071-42397000-3bd7-11eb-9537-6d3591b5a776.png">

```
[opentelemetry.auto.trace 2020-12-11 17:30:12:708 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://trace-api.newrelic.com/trace/v1
[opentelemetry.auto.trace 2020-12-11 17:30:12:708 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-11 17:30:12:728 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed span exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter
[opentelemetry.auto.trace 2020-12-11 17:30:12:736 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with endpoint https://metric-api.newrelic.com/metric/v1
[opentelemetry.auto.trace 2020-12-11 17:30:12:737 -0800] [main] INFO com.newrelic.telemetry.transport.BatchDataSender - BatchDataSender configured with audit logging enabled.
[opentelemetry.auto.trace 2020-12-11 17:30:12:739 -0800] [main] INFO io.opentelemetry.javaagent.tooling.TracerInstaller - Installed metric exporter: com.newrelic.telemetry.opentelemetry.export.NewRelicMetricExporter
[opentelemetry.auto.trace 2020-12-11 17:30:12:750 -0800] [main] INFO io.opentelemetry.javaagent.tooling.VersionLogger - opentelemetry-javaagent - version: 0.12.1
...
[opentelemetry.auto.trace 2020-12-11 17:31:12:748 -0800] [IntervalMetricReader_1] DEBUG com.newrelic.telemetry.metrics.MetricBuffer - Creating metric batch.
[opentelemetry.auto.trace 2020-12-11 17:31:12:749 -0800] [Thread-9] DEBUG com.newrelic.telemetry.metrics.MetricBatchSender - Sending a metric batch (number of metrics: 1) to the New Relic metric ingest endpoint)
[opentelemetry.auto.trace 2020-12-11 17:31:12:749 -0800] [Thread-9] DEBUG com.newrelic.telemetry.metrics.json.MetricBatchMarshaller - Generating json for metric batch.
[opentelemetry.auto.trace 2020-12-11 17:31:12:753 -0800] [Thread-9] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json: [{"common":{"attributes":{"service.name":"otel-distro-test","service.instance.id":"be91b85c-cc8f-4bf3-a6ce-09802401ce27","collector.name":"newrelic-opentelemetry-exporter","instrumentation.provider":"opentelemetry"}},"metrics":[{"name":"processedSpans","type":"count","value":129.0,"timestamp":1607736612731,"interval.ms":60010,"attributes":{"dropped":"false","description":"The number of spans processed by the BatchSpanProcessor. [dropped=true if they were dropped due to high throughput]","process.runtime.version":"11.0.8+10","instrumentation.name":"io.opentelemetry.sdk.trace","process.pid":64765,"telemetry.sdk.name":"opentelemetry","telemetry.sdk.language":"java","unit":"1","process.runtime.name":"OpenJDK Runtime Environment","os.description":"Mac OS X 10.15.7","process.executable.path":"/Users/jkeller/.sdkman/candidates/java/11.0.8.hs-adpt:bin:java","process.command_line":"/Users/jkeller/.sdkman/candidates/java/11.0.8.hs-adpt:bin:java -javaagent:/Users/jkeller/code/spring-petclinic/opentelemetry/opentelemetry-javaagent-0.12.1-all.jar -Dotel.exporter.jar=/Users/jkeller/code/opentelemetry-exporter-java/opentelemetry-exporters-newrelic-auto/build/libs/opentelemetry-exporters-newrelic-auto-0.12.0-SNAPSHOT.jar -Dnewrelic.api.key=NRII-Jg0aDK9COoJZM6KbJkL3gcciE8fkF5Fi -Dnewrelic.service.name=otel-distro-test -Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug -Dnewrelic.enable.audit.logging=true -XX:TieredStopAtLevel=1 -Xverify:none -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=54068:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8","os.name":"DARWIN","telemetry.sdk.version":"0.12.0","spanProcessorType":"BatchSpanProcessor","process.runtime.description":"AdoptOpenJDK OpenJDK 64-Bit Server VM 11.0.8+10","telemetry.auto.version":"0.12.1"}}]}]
[opentelemetry.auto.trace 2020-12-11 17:31:13:023 -0800] [Thread-9] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API: code: 202, body: {"requestId":"edb99afa-0025-b000-0000-01765492c2c6"}
[opentelemetry.auto.trace 2020-12-11 17:31:13:023 -0800] [Thread-9] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry batch sent
...
[opentelemetry.auto.trace 2020-12-11 17:32:13:853 -0800] [Thread-6] DEBUG com.newrelic.telemetry.spans.SpanBatchSender - Sending a span batch (number of spans: 5) to the New Relic span ingest endpoint)
[opentelemetry.auto.trace 2020-12-11 17:32:13:853 -0800] [Thread-6] DEBUG com.newrelic.telemetry.spans.json.SpanBatchMarshaller - Generating json for span batch.
[opentelemetry.auto.trace 2020-12-11 17:32:13:854 -0800] [Thread-6] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Sending json: [{"common":{"attributes":{"service.name":"otel-distro-test","process.runtime.version":"11.0.8+10","process.pid":64765,"telemetry.sdk.name":"opentelemetry","telemetry.sdk.language":"java","process.runtime.name":"OpenJDK Runtime Environment","service.instance.id":"be91b85c-cc8f-4bf3-a6ce-09802401ce27","os.description":"Mac OS X 10.15.7","process.executable.path":"/Users/jkeller/.sdkman/candidates/java/11.0.8.hs-adpt:bin:java","process.command_line":"/Users/jkeller/.sdkman/candidates/java/11.0.8.hs-adpt:bin:java -javaagent:/Users/jkeller/code/spring-petclinic/opentelemetry/opentelemetry-javaagent-0.12.1-all.jar -Dotel.exporter.jar=/Users/jkeller/code/opentelemetry-exporter-java/opentelemetry-exporters-newrelic-auto/build/libs/opentelemetry-exporters-newrelic-auto-0.12.0-SNAPSHOT.jar -Dnewrelic.api.key=NRII-Jg0aDK9COoJZM6KbJkL3gcciE8fkF5Fi -Dnewrelic.service.name=otel-distro-test -Dio.opentelemetry.javaagent.slf4j.simpleLogger.log.com.newrelic.telemetry=debug -Dnewrelic.enable.audit.logging=true -XX:TieredStopAtLevel=1 -Xverify:none -Dspring.output.ansi.enabled=always -Dcom.sun.management.jmxremote -Dspring.jmx.enabled=true -Dspring.liveBeansView.mbeanDomain -Dspring.application.admin.enabled=true -javaagent:/Applications/IntelliJ IDEA.app/Contents/lib/idea_rt.jar=54068:/Applications/IntelliJ IDEA.app/Contents/bin -Dfile.encoding=UTF-8","os.name":"DARWIN","telemetry.sdk.version":"0.12.0","process.runtime.description":"AdoptOpenJDK OpenJDK 64-Bit Server VM 11.0.8+10","telemetry.auto.version":"0.12.1","collector.name":"newrelic-opentelemetry-exporter","instrumentation.provider":"opentelemetry"}},"spans":[{"id":"217f556ad42b9980","trace.id":"078f8ffb68c25062e65a2af1d01138e2","timestamp":1607736731851,"attributes":{"duration.ms":0.237721,"instrumentation.version":"0.12.1","span.kind":"INTERNAL","name":"WelcomeController.welcome","parent.id":"f7ad78267ee70887","instrumentation.name":"io.opentelemetry.javaagent.spring-webmvc","thread.name":"http-nio-8080-exec-10","thread.id":216}},{"id":"978587f56c3e2645","trace.id":"078f8ffb68c25062e65a2af1d01138e2","timestamp":1607736731851,"attributes":{"duration.ms":28.284732,"instrumentation.version":"0.12.1","spring-webmvc.view.name":"welcome","span.kind":"INTERNAL","name":"Render welcome","parent.id":"f7ad78267ee70887","instrumentation.name":"io.opentelemetry.javaagent.spring-webmvc","thread.name":"http-nio-8080-exec-10","thread.id":216}},{"id":"f7ad78267ee70887","trace.id":"078f8ffb68c25062e65a2af1d01138e2","timestamp":1607736731850,"attributes":{"duration.ms":30.748486,"net.peer.port":54080,"http.flavor":"HTTP/1.1","http.url":"http://localhost:8080/","instrumentation.name":"io.opentelemetry.javaagent.servlet","thread.name":"http-nio-8080-exec-10","net.peer.ip":"0:0:0:0:0:0:0:1","http.client_ip":"0:0:0:0:0:0:0:1","http.status_code":200,"instrumentation.version":"0.12.1","span.kind":"SERVER","http.user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36","name":"/","http.method":"GET","thread.id":216}},{"id":"9b27828251c09f9d","trace.id":"8a21acf97bf4b8fe1e106e42931ffbf0","timestamp":1607736732117,"attributes":{"duration.ms":1.388774,"instrumentation.version":"0.12.1","span.kind":"INTERNAL","name":"ResourceHttpRequestHandler.handleRequest","parent.id":"2c56557355d92f7f","instrumentation.name":"io.opentelemetry.javaagent.spring-webmvc","thread.name":"http-nio-8080-exec-1","thread.id":207}},{"id":"2c56557355d92f7f","trace.id":"8a21acf97bf4b8fe1e106e42931ffbf0","timestamp":1607736732116,"attributes":{"duration.ms":3.203103,"net.peer.port":54080,"http.flavor":"HTTP/1.1","http.url":"http://localhost:8080/resources/images/favicon.png","instrumentation.name":"io.opentelemetry.javaagent.servlet","thread.name":"http-nio-8080-exec-1","net.peer.ip":"0:0:0:0:0:0:0:1","http.client_ip":"0:0:0:0:0:0:0:1","http.status_code":200,"instrumentation.version":"0.12.1","span.kind":"SERVER","http.user_agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36","name":"/**","http.method":"GET","thread.id":207}}]}]
[opentelemetry.auto.trace 2020-12-11 17:32:13:925 -0800] [Thread-6] DEBUG com.newrelic.telemetry.transport.BatchDataSender - Response from New Relic ingest API: code: 202, body: {"requestId":"9d8d9ca0-0001-b000-0000-01765493b0c4"}
[opentelemetry.auto.trace 2020-12-11 17:32:13:925 -0800] [Thread-6] DEBUG com.newrelic.telemetry.TelemetryClient - Telemetry batch sent
```


Addresses #133 