### PR TITLE
Add support for OTel 0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Coming soon
 - tbd
 
+## [0.13.0] - 2020-12-14
+- Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.13.1`
+- Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.13.1`
+- Updates compatibility with `com.newrelic.telemetry:telemetry::0.10.0`
+- Updates compatibility with `com.newrelic.telemetry:telemetry-http-okhttp::0.10.0`
+
 ## [0.12.0] - 2020-12-14
 - Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.12.0`
 - Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.12.1`

--- a/opentelemetry-exporters-newrelic-auto/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic-auto/build.gradle.kts
@@ -15,8 +15,8 @@ dependencies {
     annotationProcessor("com.google.auto.service:auto-service:1.0-rc7")
     api("com.google.auto.service:auto-service-annotations:1.0-rc7")
     api(project(":opentelemetry-exporters-newrelic"))
-    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.12.1")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.12.0")
+    implementation("io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.13.1")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.13.1")
 
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")

--- a/opentelemetry-exporters-newrelic/build.gradle.kts
+++ b/opentelemetry-exporters-newrelic/build.gradle.kts
@@ -1,10 +1,10 @@
 dependencies {
-    val newRelicTelemetrySdkVersion = "0.9.0"
+    val newRelicTelemetrySdkVersion = "0.10.0"
 
     api("com.newrelic.telemetry:telemetry:$newRelicTelemetrySdkVersion")
     implementation("org.slf4j:slf4j-api:1.7.26")
     implementation("com.newrelic.telemetry:telemetry-http-okhttp:$newRelicTelemetrySdkVersion")
-    implementation("io.opentelemetry:opentelemetry-sdk:0.12.0")
+    implementation("io.opentelemetry:opentelemetry-sdk:0.13.1")
 
     testRuntimeOnly("org.slf4j:slf4j-simple:1.7.26")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.4.2")

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/MetricPointAdapter.java
@@ -102,7 +102,7 @@ public class MetricPointAdapter {
     if (isNonMonotonic(metric)) {
       return singleton(
           new Gauge(metric.getName(), value, NANOSECONDS.toMillis(epochNanos), attributes));
-    } else {
+    } else if (!isNonMonotonic(metric)) {
       return singleton(
           new Count(
               metric.getName(),
@@ -111,6 +111,8 @@ public class MetricPointAdapter {
               NANOSECONDS.toMillis(epochNanos),
               attributes));
     }
+    // unhandled types
+    return emptyList();
   }
 
   private Collection<Metric> buildSummaryPointMetrics(

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicMetricExporter.java
@@ -113,8 +113,9 @@ public class NewRelicMetricExporter implements MetricExporter {
   }
 
   @Override
-  public void shutdown() {
+  public CompletableResultCode shutdown() {
     telemetryClient.shutdown();
+    return CompletableResultCode.ofSuccess();
   }
 
   private Attributes buildCommonAttributes(MetricData metric) {


### PR DESCRIPTION
Lots of refactoring to be compatible with the OTel SDK 0.13.1 release.

```
- Updates compatibility with `io.opentelemetry:opentelemetry-sdk:0.13.1`
- Updates compatibility with `io.opentelemetry.javaagent:opentelemetry-javaagent-spi:0.13.1`
- Updates compatibility with `com.newrelic.telemetry:telemetry::0.10.0`
- Updates compatibility with `com.newrelic.telemetry:telemetry-http-okhttp::0.10.0`
```

Resolves #145 