### PR TITLE
Fix publishing to compile with Java 8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,18 +14,6 @@ apply(plugin = "signing")
 
 apply(plugin = "com.github.sherter.google-java-format")
 
-tasks.withType<JavaCompile>().configureEach {
-    javaCompiler.set(javaToolchains.compilerFor {
-        languageVersion.set(JavaLanguageVersion.of(8))
-    })
-}
-
-tasks.withType<Test>().configureEach {
-    javaLauncher.set(javaToolchains.launcherFor {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    })
-}
-
 allprojects {
     group = "com.newrelic.telemetry"
 
@@ -38,11 +26,21 @@ allprojects {
         // this is only needed for the working against unreleased otel-java snapshots
         maven("https://oss.jfrog.org/artifactory/oss-snapshot-local")
     }
-    tasks.withType<Test> {
+    tasks.withType<JavaCompile>().configureEach {
+        // compile all projects with Java 8
+        javaCompiler.set(javaToolchains.compilerFor {
+            languageVersion.set(JavaLanguageVersion.of(8))
+        })
+    }
+    tasks.withType<Test>().configureEach {
         useJUnitPlatform()
         testLogging {
             events("passed", "skipped", "failed")
         }
+        // run tests in all projects with Java 11
+        javaLauncher.set(javaToolchains.launcherFor {
+            languageVersion.set(JavaLanguageVersion.of(11))
+        })
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@
 # Passing in -Prelease=true will render a non-snapshot version.
 # All other values (including unset) will render a snapshot version.
 
-baseVersion = 0.14.0
+baseVersion = 0.13.1
 
 # set this to true to enable using a local sonatype (for debugging publishing issues)
 # (start a local sonatype in docker with this command: $ docker run -d -p 8081:8081 --name nexus sonatype/nexus3)

--- a/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicExporters.java
+++ b/opentelemetry-exporters-newrelic/src/main/java/com/newrelic/telemetry/opentelemetry/export/NewRelicExporters.java
@@ -9,7 +9,9 @@ import static java.util.Collections.singleton;
 
 import com.newrelic.telemetry.Attributes;
 import com.newrelic.telemetry.opentelemetry.export.NewRelicSpanExporter.Builder;
+import io.opentelemetry.api.metrics.GlobalMetricsProvider;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.IntervalMetricReader;
 import io.opentelemetry.sdk.trace.export.BatchSpanProcessor;
 
@@ -19,12 +21,19 @@ public class NewRelicExporters {
 
   /**
    * Start up the New Relic Metric and Span exporters with the provided API key and service name.
+   *
+   * @param apiKey API key
+   * @param serviceName Service name
    */
   public static void start(String apiKey, String serviceName) {
     start(new Configuration(apiKey, serviceName));
   }
 
-  /** Start up the New Relic Metric and Span exporters with the provided configuration. */
+  /**
+   * Start up the New Relic Metric and Span exporters with the provided configuration.
+   *
+   * @param configuration Configuration
+   */
   public static void start(Configuration configuration) {
     Attributes serviceNameAttributes =
         new Attributes().put("service.name", configuration.serviceName);
@@ -55,7 +64,7 @@ public class NewRelicExporters {
             .setExportIntervalMillis(configuration.collectionIntervalSeconds * 1000)
             .setMetricExporter(metricExporterBuilder.build())
             .setMetricProducers(
-                singleton(OpenTelemetrySdk.getGlobalMeterProvider().getMetricProducer()))
+                singleton(((SdkMeterProvider) GlobalMetricsProvider.get()).getMetricProducer()))
             .build();
   }
 
@@ -90,6 +99,8 @@ public class NewRelicExporters {
      * Turn on audit logging for the exporters. Please note that this will expose all your telemetry
      * data to your logging system. Requires the slf4j "com.newrelic.telemetry" logger to be enabled
      * at DEBUG level. Defaults to being off.
+     *
+     * @return Configuration
      */
     public Configuration enableAuditLogging() {
       this.enableAuditLogging = true;
@@ -98,6 +109,9 @@ public class NewRelicExporters {
 
     /**
      * Set the collection interval, in seconds, for both metrics and spans. Defaults to 5 seconds.
+     *
+     * @param interval Interval in seconds
+     * @return Configuration
      */
     public Configuration collectionIntervalSeconds(int interval) {
       collectionIntervalSeconds = interval;


### PR DESCRIPTION
Resolves #149 

A previous change to the `build.gradle.kts` (#128) resulted in the project being compiled by Java 11 instead of 8. This PR should fix the issue so that the exporter can run on earlier versions of Java once again.